### PR TITLE
[BUFGIX] Journaliser le temps de réponse au format JSON

### DIFF
--- a/lib/application/task-response-time.js
+++ b/lib/application/task-response-time.js
@@ -14,7 +14,7 @@ async function taskResponseTime() {
   await client.query('SELECT id FROM users ORDER BY RANDOM() LIMIT 1');
   const duration = Date.now() - startTime;
 
-  logger.info({ event: 'response-time-millis' , data: duration });
+  logger.info({ event: 'response-time-millis' , data: { duration } });
 
   client.end();
 }


### PR DESCRIPTION
## :unicorn: Problème
La métrique est bien tracée, mais elle n'est pas interprétable par Datadog

## :robot: Solution
Logguer un objet au format JSOn sous `data`

## :100: Pour tester
Consulter les logs[ de la RA](dashboard-prev.osc-fr1.scalingo.com/apps/pix-db-stats-pr6/logs)

`2021-07-23 18:08:00.045260863 +0200 CEST [clock-1] {"event":"response-time-millis","data":{"duration":31}}`

Mettre en production pour vérifier le parsing