### PR TITLE
Ajout de l'enregistrement de l'avancement des opérations longues

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 
-const DEFAULT_RESPONSE_TIME_QUERY = 'SELECT pg_sleep(1)'
+const DEFAULT_RESPONSE_TIME_QUERY = 'SELECT pg_sleep(1)';
+const DEFAULT_PROGRESS_SCHEDULE = '0 */10 * * * *';
 
 module.exports = {
   SCALINGO_REGION: process.env.SCALINGO_REGION,
@@ -9,9 +10,11 @@ module.exports = {
   FT_METRICS: process.env.FT_METRICS === 'yes',
   FT_STATEMENTS: process.env.FT_STATEMENTS === 'yes',
   FT_RESPONSE_TIME: process.env.FT_RESPONSE_TIME === 'yes',
+  FT_PROGRESS: process.env.FT_PROGRESS === 'yes',
   METRICS_SCHEDULE: process.env.METRICS_SCHEDULE,
   STATEMENTS_SCHEDULE: process.env.STATEMENTS_SCHEDULE,
   RESPONSE_TIME_SCHEDULE: process.env.RESPONSE_TIME_SCHEDULE,
   RESPONSE_TIME_QUERY: process.env.RESPONSE_TIME_QUERY || DEFAULT_RESPONSE_TIME_QUERY ,
   MONITORED_DATABASE_URL: process.env.MONITORED_DATABASE_URL,
+  PROGRESS_SCHEDULE: process.env.PROGRESS_SCHEDULE || DEFAULT_PROGRESS_SCHEDULE,
 };

--- a/lib/application/run-task-progress.js
+++ b/lib/application/run-task-progress.js
@@ -1,0 +1,6 @@
+const taskProgress = require('./task-progress');
+
+(async ()=>{
+  await taskProgress();
+})()
+

--- a/lib/application/schedule-tasks.js
+++ b/lib/application/schedule-tasks.js
@@ -4,13 +4,16 @@ const {
   FT_METRICS,
   FT_STATEMENTS,
   FT_RESPONSE_TIME,
+  FT_PROGRESS,
   METRICS_SCHEDULE,
   STATEMENTS_SCHEDULE,
-  RESPONSE_TIME_SCHEDULE
+  RESPONSE_TIME_SCHEDULE,
+  PROGRESS_SCHEDULE,
 } = require('../../config');
 const taskMetrics = require('./task-metrics');
 const taskStatements = require('./task-statements');
 const taskResponseTime = require('./task-response-time');
+const taskProgress = require('./task-progress');
 
 if (FT_METRICS){
   new CronJob(METRICS_SCHEDULE, taskMetrics, null, true, parisTimezone);
@@ -22,5 +25,9 @@ if (FT_STATEMENTS) {
 
 if(FT_RESPONSE_TIME){
   new CronJob(RESPONSE_TIME_SCHEDULE, taskResponseTime, null, true, parisTimezone);
+}
+
+if(FT_PROGRESS){
+  new CronJob(PROGRESS_SCHEDULE, taskProgress, null, true, parisTimezone);
 }
 

--- a/lib/application/task-progress.js
+++ b/lib/application/task-progress.js
@@ -1,0 +1,29 @@
+const { Client } = require('pg');
+const logger = require('../infrastructure/logger');
+const {
+  MONITORED_DATABASE_URL,
+} = require('../../config');
+
+const PROGRESS_VIEW_PREFIX = 'pg_stat_progress_';
+
+const taskProgress = async ()=>{
+
+  const client = new Client(MONITORED_DATABASE_URL);
+
+  try {
+    await client.connect();
+
+    const { rows: views } = await client.query(`SELECT relname FROM pg_class WHERE relname LIKE '${PROGRESS_VIEW_PREFIX}%'`);
+
+    for(const { relname: view } of views) {
+      const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
+      const { rows: entries } = await client.query(`SELECT * from ${view}`);
+      entries.forEach((entry) => logger.info({ event: 'progress', data: { operation, ...entry } }))
+    }
+
+  } finally {
+    await client.end();
+  }
+}
+
+module.exports = taskProgress;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "metrics": "node ./lib/application/run-task-metrics.js",
     "statements": "node ./lib/application/run-task-statements.js",
     "response-time": "node ./lib/application/run-task-response-time.js",
+    "progress": "node ./lib/application/run-task-progress.js",
     "schedule-tasks": "node ./lib/application/schedule-tasks.js"
   },
   "repository": {

--- a/sample.env
+++ b/sample.env
@@ -82,6 +82,13 @@ FT_STATEMENTS=yes
 # value: yes to activate
 FT_RESPONSE_TIME=yes
 
+# Enable progress (vacuum, create index...) monitoring
+#
+# presence: optional
+# type: text
+# value: yes to activate
+FT_PROGRESS=yes
+
 # Execution periodicity (for node-cron library, in a cron-like pattern)
 # Cron patterns have five fields, and 1 minute as the finest granularity
 # But this library has six fields, with 1 second as the finest granularity.
@@ -113,6 +120,13 @@ STATEMENTS_SCHEDULE=* * */1 * * *
 # default: none
 # each 15 seconds
 RESPONSE_TIME_SCHEDULE=*/15 * * * * *
+
+# Progress reporting schedule
+#
+# presence: optional
+# type: text
+# default: 0 */10 * * * *
+PROGRESS_SCHEDULE=0 */10 * * * *
 
 # =========
 # RESPONSE_TIME


### PR DESCRIPTION
## :unicorn: Problème

Nous aimerions pouvoir suivre l'avancement de certaines opérations longues comme `VACUUM` ou `CREATE INDEX`.

## :robot: Solution

PostgreSQL fournit des vues pour suivre l'avancement de ces opérations : https://www.postgresql.org/docs/current/progress-reporting.html, on va donc interroger ces vues à intervalle régulier et copier leur contenu dans le log pour indexation.

La liste des vues concernées varie selon la version de PostgreSQL, c'est pourquoi on récupère la liste des vues commençant par `pg_stat_progress_` avant de toutes les interroger.

Des événements `progress` sont générés. Une propriété `operation` est ajoutée aux colonnes de la vue concernée, contenant le suffixe suivant `pg_stat_progress_` dans le nom de la vue (ex. `vacuum`, `create_index`…).

## :100: Pour tester

Lancer une opération `VACUUM` par exemple, constater que des entrées de ce type apparaissent dans le log :
```
{"event":"progress","data":{"operation":"vacuum","pid":9969,"datid":27773,"datname":"pix_dev","relid":28172,"phase":"scanning heap","heap_blks_total":"44148","heap_blks_scanned":"8359","heap_blks_vacuumed":"0","index_vacuum_count":"0","max_dead_tuples":"11184810","num_dead_tuples":"0"}}
```

## ⚠️ Remarque

Pour avoir la moindre information sur une opération en cours, il faut interroger la vue `pg_stat_progress_*` correspondante en étant connecté avec le même utilisateur que celui qui a lancé l'opération (ou le super-utilisateur mais on n'y a pas accès sur Scalingo). Le plus propre serait d'obtenir de Scalingo d'avoir un utilisateur ayant le rôle `pg_read_all_stats` ou `pg_monitor` (qui inclut le précédent). À défaut, il faut que `MONITORED_DATABASE_URL` contienne une chaîne de connexion qui permet de se connecter avec le même utilisateur que celui qui a lancé l'opération (impossible donc d'utiliser un compte en lecture seule).

Cela signifie aussi que pour les `VACUUM` lancés automatiquement par PostgreSQL, on n'a aucune autre information que le fait qu'une telle opération est en cours.