### PR TITLE
[FEATURE] Monitore plusieurs applications

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ function _isFeatureEnabled(valueString) {
 
 module.exports = {
   SCALINGO_REGION: process.env.SCALINGO_REGION,
-  SCALINGO_APP: process.env.SCALINGO_APP,
+  SCALINGO_APPS: JSON.parse(process.env.SCALINGO_APPS || '[]'),
   SCALINGO_TOKEN: process.env.SCALINGO_TOKEN,
   FT_METRICS: _isFeatureEnabled(process.env.FT_METRICS),
   FT_STATEMENTS: _isFeatureEnabled(process.env.FT_STATEMENTS),

--- a/config.js
+++ b/config.js
@@ -3,14 +3,18 @@ require('dotenv').config();
 const DEFAULT_RESPONSE_TIME_QUERY = 'SELECT pg_sleep(1)';
 const DEFAULT_PROGRESS_SCHEDULE = '0 */10 * * * *';
 
+function _isFeatureEnabled(valueString) {
+  return valueString === 'yes';
+}
+
 module.exports = {
   SCALINGO_REGION: process.env.SCALINGO_REGION,
   SCALINGO_APP: process.env.SCALINGO_APP,
   SCALINGO_TOKEN: process.env.SCALINGO_TOKEN,
-  FT_METRICS: process.env.FT_METRICS === 'yes',
-  FT_STATEMENTS: process.env.FT_STATEMENTS === 'yes',
-  FT_RESPONSE_TIME: process.env.FT_RESPONSE_TIME === 'yes',
-  FT_PROGRESS: process.env.FT_PROGRESS === 'yes',
+  FT_METRICS: _isFeatureEnabled(process.env.FT_METRICS),
+  FT_STATEMENTS: _isFeatureEnabled(process.env.FT_STATEMENTS),
+  FT_RESPONSE_TIME: _isFeatureEnabled(process.env.FT_RESPONSE_TIME),
+  FT_PROGRESS: _isFeatureEnabled(process.env.FT_PROGRESS),
   METRICS_SCHEDULE: process.env.METRICS_SCHEDULE,
   STATEMENTS_SCHEDULE: process.env.STATEMENTS_SCHEDULE,
   RESPONSE_TIME_SCHEDULE: process.env.RESPONSE_TIME_SCHEDULE,

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -1,13 +1,15 @@
 const databaseStatsRepository = require('../infrastructure/database-stats-repository');
 const logger = require('../infrastructure/logger');
-const { SCALINGO_APP } = require('../../config');
+const { SCALINGO_APPS } = require('../../config');
 
 async function taskMetrics() {
-  const stats = await databaseStatsRepository.getCPULoad();
-  logger.info({ event: 'leader-cpu', app: SCALINGO_APP, data: stats });
+  SCALINGO_APPS.forEach(async (scalingoApp) => {
+    const stats = await databaseStatsRepository.getCPULoad(scalingoApp);
+    logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
 
-  const metrics = await databaseStatsRepository.getDBMetrics();
-  logger.info({ event: 'db-metrics', app: SCALINGO_APP, data: metrics });
+    const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
+    logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
+  })
 }
 
 module.exports = taskMetrics;

--- a/lib/application/task-progress.js
+++ b/lib/application/task-progress.js
@@ -1,29 +1,31 @@
 const { Client } = require('pg');
 const logger = require('../infrastructure/logger');
 const databaseStatsRepository = require('../infrastructure/database-stats-repository');
-const { SCALINGO_APP } = require('../../config');
+const { SCALINGO_APPS } = require('../../config');
 
 const PROGRESS_VIEW_PREFIX = 'pg_stat_progress_';
 
-const taskProgress = async ()=>{
-  const dbURL = await databaseStatsRepository.getDbConnectionString();
+const taskProgress = async () => {
+  SCALINGO_APPS.forEach(async (scalingoApp) => {
+    const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
 
-  const client = new Client(dbURL);
+    const client = new Client(dbURL);
 
-  try {
-    await client.connect();
+    try {
+      await client.connect();
 
-    const { rows: views } = await client.query(`SELECT relname FROM pg_class WHERE relname LIKE '${PROGRESS_VIEW_PREFIX}%'`);
+      const { rows: views } = await client.query(`SELECT relname FROM pg_class WHERE relname LIKE '${PROGRESS_VIEW_PREFIX}%'`);
 
-    for(const { relname: view } of views) {
-      const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
-      const { rows: entries } = await client.query(`SELECT * from ${view}`);
-      entries.forEach((entry) => logger.info({ event: 'progress', app: SCALINGO_APP, data: { operation, ...entry } }))
+      for(const { relname: view } of views) {
+        const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
+        const { rows: entries } = await client.query(`SELECT * from ${view}`);
+        entries.forEach((entry) => logger.info({ event: 'progress', app: scalingoApp, data: { operation, ...entry } }))
+      }
+
+    } finally {
+      await client.end();
     }
-
-  } finally {
-    await client.end();
-  }
+  });
 }
 
 module.exports = taskProgress;

--- a/lib/application/task-response-time.js
+++ b/lib/application/task-response-time.js
@@ -1,23 +1,25 @@
 const { Client } = require('pg');
 const logger = require('../infrastructure/logger');
 const databaseStatsRepository = require('../infrastructure/database-stats-repository');
-const { SCALINGO_APP, RESPONSE_TIME_QUERY } = require('../../config');
+const { SCALINGO_APPS, RESPONSE_TIME_QUERY } = require('../../config');
 
-const taskResponseTime = async ()=>{
-  const dbURL = await databaseStatsRepository.getDbConnectionString();
+const taskResponseTime = async () => {
+  SCALINGO_APPS.forEach(async (scalingoApp) => {
+    const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
 
-  const client = new Client(dbURL);
+    const client = new Client(dbURL);
 
-  client.connect();
-  await preventWrites(client);
+    client.connect();
+    await preventWrites(client);
 
-  const startTime = Date.now();
-  await client.query(RESPONSE_TIME_QUERY);
-  const duration = Date.now() - startTime;
+    const startTime = Date.now();
+    await client.query(RESPONSE_TIME_QUERY);
+    const duration = Date.now() - startTime;
 
-  logger.info({ event: 'response-time-millis', app: SCALINGO_APP, data: { duration } });
+    logger.info({ event: 'response-time-millis', app: scalingoApp, data: { duration } });
 
-  client.end();
+    client.end();
+  });
 }
 
 const preventWrites = async (client)=>{

--- a/lib/application/task-statements.js
+++ b/lib/application/task-statements.js
@@ -1,13 +1,15 @@
 const databaseStatsRepository = require('../infrastructure/database-stats-repository');
 const logger = require('../infrastructure/logger');
-const { SCALINGO_APP } = require('../../config');
+const { SCALINGO_APPS } = require('../../config');
 
 async function task() {
-  const queryStats = await databaseStatsRepository.getQueryStats();
+  SCALINGO_APPS.forEach(async (scalingoApp) => {
+    const queryStats = await databaseStatsRepository.getQueryStats(scalingoApp);
 
-  queryStats.forEach((query) => logger.info({ event: 'db-query-stats', app: SCALINGO_APP, data: query }))
+    queryStats.forEach((query) => logger.info({ event: 'db-query-stats', app: scalingoApp, data: query }))
 
-  await databaseStatsRepository.resetQueryStats();
+    await databaseStatsRepository.resetQueryStats(scalingoApp);
+  });
 }
 
 module.exports = task;

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -1,33 +1,33 @@
 const scalingoApi = require('./scalingo-api');
 
 module.exports = {
-  async getCPULoad() {
-    const dbMetrics = await scalingoApi.getDbMetrics();
-    const nodes = await _getDatabaseNodeId();
+  async getCPULoad(scalingoApp) {
+    const dbMetrics = await scalingoApi.getDbMetrics(scalingoApp);
+    const nodes = await _getDatabaseNodeId(scalingoApp);
 
     return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, nodes);
   },
 
-  getDBMetrics() {
-    return scalingoApi.getDbMetrics();
+  getDBMetrics(scalingoApp) {
+    return scalingoApi.getDbMetrics(scalingoApp);
   },
 
-  getDbConnectionString() {
-    return scalingoApi.getDbConnectionString();
+  getDbConnectionString(scalingoApp) {
+    return scalingoApi.getDbConnectionString(scalingoApp);
   },
 
-  async getQueryStats() {
-    const { result } = await scalingoApi.getQueryStats();
+  async getQueryStats(scalingoApp) {
+    const { result } = await scalingoApi.getQueryStats(scalingoApp);
     return result || [];
   },
 
-  async resetQueryStats() {
-    await scalingoApi.resetStats();
+  async resetQueryStats(scalingoApp) {
+    await scalingoApi.resetStats(scalingoApp);
   },
 }
 
-async function _getDatabaseNodeId() {
-  const instancesStatus = await scalingoApi.getInstancesStatus();
+async function _getDatabaseNodeId(scalingoApp) {
+  const instancesStatus = await scalingoApi.getInstancesStatus(scalingoApp);
   return instancesStatus
     .filter(({ type, role }) => type === 'db-node' && role === "leader")
     .map(({ id }) => id);

--- a/lib/infrastructure/scalingo-api.js
+++ b/lib/infrastructure/scalingo-api.js
@@ -2,7 +2,6 @@ const httpService = require('./http-service');
 
 const {
   SCALINGO_REGION,
-  SCALINGO_APP,
   SCALINGO_TOKEN,
 } = require('../../config');
 
@@ -12,32 +11,32 @@ const DB_API_URL = `https://db-api.${SCALINGO_REGION}.scalingo.com`;
 const addonProvider = 'postgresql';
 
 module.exports = {
-  async getDbMetrics() {
-    const { addonId, token } = await _getScalingoDatabaseAPICredentials();
+  async getDbMetrics(scalingoApp) {
+    const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
     return _getDbMetrics(token, addonId);
   },
 
-  async getInstancesStatus() {
-    const { addonId, token } = await _getScalingoDatabaseAPICredentials();
+  async getInstancesStatus(scalingoApp) {
+    const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
     return _getInstancesStatus(token, addonId);
   },
 
-  async getDbConnectionString() {
-    return _getScalingoPgUrl();
+  async getDbConnectionString(scalingoApp) {
+    return _getScalingoPgUrl(scalingoApp);
   },
 
-  async getQueryStats() {
-    const {addonId, token} = await _getScalingoDatabaseAPICredentials();
+  async getQueryStats(scalingoApp) {
+    const {addonId, token} = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
     const config = requestConfig(token)
     const { data: stats } = await httpService.post(`${DB_API_URL}/api/databases/${addonId}/action`, config, { "action_name": "pg-stat-statements-list" });
     return stats;
   },
 
-  async resetStats() {
-    const {addonId, token} = await _getScalingoDatabaseAPICredentials();
+  async resetStats(scalingoApp) {
+    const {addonId, token} = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
     const config = requestConfig(token)
     const { data: stats } = await httpService.post(`${DB_API_URL}/api/databases/${addonId}/action`, config, { "action_name": "pg-stat-statements-reset" });
@@ -45,17 +44,17 @@ module.exports = {
   },
 }
 
-async function _getScalingoDatabaseAPICredentials() {
+async function _getScalingoDatabaseAPICredentials(scalingoApp) {
   const scalingoApplicationToken = await _getScalingoApplicationToken()
-  const addonId = await _getPgAddonId(scalingoApplicationToken);
-  const addonToken = await _getPgAddonToken(scalingoApplicationToken, addonId);
+  const addonId = await _getPgAddonId(scalingoApp, scalingoApplicationToken);
+  const addonToken = await _getPgAddonToken(scalingoApp, scalingoApplicationToken, addonId);
 
   return { addonId, token: addonToken };
 }
 
-async function _getScalingoPgUrl() {
+async function _getScalingoPgUrl(scalingoApp) {
   const scalingoApplicationToken = await _getScalingoApplicationToken();
-  const environmentVariables = await _getScalingoEnvVariables(scalingoApplicationToken);
+  const environmentVariables = await _getScalingoEnvVariables(scalingoApp, scalingoApplicationToken);
 
   return environmentVariables.variables.find((variable) => {
     return variable.name === 'SCALINGO_POSTGRESQL_URL';
@@ -69,15 +68,15 @@ async function _getScalingoApplicationToken() {
   return data.token;
 }
 
-async function _getScalingoEnvVariables(token) {
+async function _getScalingoEnvVariables(scalingoApp, token) {
   const config = requestConfig(token)
-  const { data } = await httpService.get(`${SCALINGO_API_URL}/apps/${SCALINGO_APP}/variables`, config);
+  const { data } = await httpService.get(`${SCALINGO_API_URL}/apps/${scalingoApp}/variables`, config);
   return data;
 }
 
-async function _getPgAddonId(token) {
+async function _getPgAddonId(scalingoApp, token) {
   const config = requestConfig(token)
-  const { data } = await httpService.get(`${SCALINGO_API_URL}/apps/${SCALINGO_APP}/addons`, config);
+  const { data } = await httpService.get(`${SCALINGO_API_URL}/apps/${scalingoApp}/addons`, config);
   const pgAddon = data.addons.find(addon => addon['addon_provider'].id === addonProvider);
   return pgAddon.id;
 }
@@ -98,9 +97,9 @@ async function _getInstancesStatus(addonToken, addonId) {
   return data;
 }
 
-async function _getPgAddonToken(token, addonId) {
+async function _getPgAddonToken(scalingoApp, token, addonId) {
   const config = requestConfig(token)
-  const url = `${SCALINGO_API_URL}/apps/${SCALINGO_APP}/addons/${addonId}/token`;
+  const url = `${SCALINGO_API_URL}/apps/${scalingoApp}/addons/${addonId}/token`;
   const { data } = await httpService.post(url, config);
   return data.addon.token;
 }

--- a/sample.env
+++ b/sample.env
@@ -29,13 +29,13 @@
 # default: none
 SCALINGO_REGION=
 
-# Name of the application whose database is to be monitored
+# Name of the applications whose databases has to be monitored
 # If not present, the application will crash
 #
 # presence: required
-# type: text
+# type: array of text
 # default: none
-SCALINGO_APP=
+SCALINGO_APPS=
 
 # =========
 # AUTHENTICATION


### PR DESCRIPTION
## :unicorn: Problème
Une instance de db-stats ne peut monitorer que une seule application. Cela nécessite dans notre cas de multiplier des instances avec son paramétrage et ses tokens scalingo.

## :robot: Solution
Rajouter le support de multiple applications pour pouvoir n'en avoir qu'une seule par région.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Voir RA
