### PR TITLE
[FEATURE] Ajout des stats d'IO et disk

### DIFF
--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -4,11 +4,16 @@ const { SCALINGO_APPS } = require('../../config');
 
 async function taskMetrics() {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
-    const stats = await databaseStatsRepository.getCPULoad(scalingoApp);
-    logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
-
+    const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApp);
     const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
+
+    const stats = await databaseStatsRepository.getCPULoad(metrics, leaderNodeId);
+
+    logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
     logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
+
+    const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
+    logger.info({ event: 'db-disk', app: scalingoApp, data: disk });
   })
 }
 

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -14,6 +14,9 @@ async function taskMetrics() {
 
     const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
     logger.info({ event: 'db-disk', app: scalingoApp, data: disk });
+
+    const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApp, leaderNodeId);
+    logger.info({ event: 'db-diskio', app: scalingoApp, data: diskio });
   })
 }
 

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -1,15 +1,21 @@
 const scalingoApi = require('./scalingo-api');
 
 module.exports = {
-  async getCPULoad(scalingoApp) {
-    const dbMetrics = await scalingoApi.getDbMetrics(scalingoApp);
-    const node = await _getDatabaseLeaderNodeId(scalingoApp);
+  async getCPULoad(dbMetrics, leaderNodeId) {
+    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, leaderNodeId);
+  },
 
-    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, node);
+  getDatabaseLeaderNodeId(scalingoApp) {
+    return _getDatabaseLeaderNodeId(scalingoApp);
   },
 
   getDBMetrics(scalingoApp) {
     return scalingoApi.getDbMetrics(scalingoApp);
+  },
+
+  async getDBDisk(scalingoApp, leaderNodeId) {
+    const { disk_used, disk_total } = await scalingoApi.getDbDisk(scalingoApp, leaderNodeId);
+    return { disk_total, disk_used };
   },
 
   getDbConnectionString(scalingoApp) {

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -3,9 +3,9 @@ const scalingoApi = require('./scalingo-api');
 module.exports = {
   async getCPULoad(scalingoApp) {
     const dbMetrics = await scalingoApi.getDbMetrics(scalingoApp);
-    const nodes = await _getDatabaseNodeId(scalingoApp);
+    const node = await _getDatabaseLeaderNodeId(scalingoApp);
 
-    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, nodes);
+    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, node);
   },
 
   getDBMetrics(scalingoApp) {
@@ -26,18 +26,18 @@ module.exports = {
   },
 }
 
-async function _getDatabaseNodeId(scalingoApp) {
+async function _getDatabaseLeaderNodeId(scalingoApp) {
   const instancesStatus = await scalingoApi.getInstancesStatus(scalingoApp);
   return instancesStatus
     .filter(({ type, role }) => type === 'db-node' && role === "leader")
-    .map(({ id }) => id);
+    .map(({ id }) => id)[0];
 }
 
 
-function _extractCPUUsageForDatabaseLeaderNode(dbMetrics, nodes) {
+function _extractCPUUsageForDatabaseLeaderNode(dbMetrics, node) {
   const {
     instance_id,
     cpu
-  } = Object.values(dbMetrics.instances_metrics).find(({ instance_id }) => nodes.includes(instance_id));
+  } = dbMetrics.instances_metrics[node];
   return { "instance_id": instance_id, "cpu": cpu.usage_in_percents };
 }

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -18,6 +18,11 @@ module.exports = {
     return { disk_total, disk_used };
   },
 
+  async getDBDiskIO(scalingoApp, leaderNodeId) {
+    const { diskio_reads, diskio_writes } = await scalingoApi.getDbDiskIO(scalingoApp, leaderNodeId);
+    return { diskio_reads, diskio_writes };
+  },
+
   getDbConnectionString(scalingoApp) {
     return scalingoApi.getDbConnectionString(scalingoApp);
   },

--- a/lib/infrastructure/scalingo-api.js
+++ b/lib/infrastructure/scalingo-api.js
@@ -17,6 +17,12 @@ module.exports = {
     return _getDbMetrics(token, addonId);
   },
 
+  async getDbDisk(scalingoApp, leaderNodeId) {
+    const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
+
+    return _getDbDisk(token, addonId, leaderNodeId);
+  },
+
   async getInstancesStatus(scalingoApp) {
     const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
@@ -89,6 +95,13 @@ async function _getDbMetrics(addonToken, addonId) {
   const config = requestConfig(addonToken)
   const { data: metrics } = await httpService.get(`${DB_API_URL}/api/databases/${addonId}/metrics`, config);
   return metrics;
+}
+
+async function _getDbDisk(addonToken, addonId, instanceId) {
+  const config = requestConfig(addonToken);
+
+  const { data: metrics } = await httpService.get(`${DB_API_URL}/api/databases/${addonId}/instances/${instanceId}/metrics/disk?since=3&last=true`, config);
+  return metrics.disk_metrics[0];
 }
 
 async function _getInstancesStatus(addonToken, addonId) {

--- a/lib/infrastructure/scalingo-api.js
+++ b/lib/infrastructure/scalingo-api.js
@@ -23,6 +23,12 @@ module.exports = {
     return _getDbDisk(token, addonId, leaderNodeId);
   },
 
+  async getDbDiskIO(scalingoApp, leaderNodeId) {
+    const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
+
+    return _getDbDiskIO(token, addonId, leaderNodeId);
+  },
+
   async getInstancesStatus(scalingoApp) {
     const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
@@ -102,6 +108,13 @@ async function _getDbDisk(addonToken, addonId, instanceId) {
 
   const { data: metrics } = await httpService.get(`${DB_API_URL}/api/databases/${addonId}/instances/${instanceId}/metrics/disk?since=3&last=true`, config);
   return metrics.disk_metrics[0];
+}
+
+async function _getDbDiskIO(addonToken, addonId, instanceId) {
+  const config = requestConfig(addonToken);
+
+  const { data: metrics } = await httpService.get(`${DB_API_URL}/api/databases/${addonId}/instances/${instanceId}/metrics/diskio?since=3&last=true`, config);
+  return metrics.diskio_metrics[0];
 }
 
 async function _getInstancesStatus(addonToken, addonId) {


### PR DESCRIPTION
## :unicorn: Problème
Scalingo a rajouté des stats sur la taille du disque et les IO sur leur dashboard. Les rajouter dans nos stats pour datadog serait chouette.

## :robot: Solution
Rajouter ces infos dans la tache metrics.

## :rainbow: Remarques
Les APIs utilisés pour le disk et les io ne sont pas publiques/documenté. Scalingo m'a prévenu que tant que ce n'était pas le cas, des changements pouvait avoir lieu. Il faudra être vigilant si ça casse pour une raison ou pour une autre.

## :100: Pour tester
Voir la RA avec les infos de disk et d'io qui sont affichés.
