### PR TITLE
:bug: Les statistiques de requêtes ne sont plus tracées

### DIFF
--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -27,7 +27,7 @@ module.exports = {
     return scalingoApi.getDbConnectionString(scalingoApp);
   },
 
-  async getQueryStats(scalingoApi, scalingoApp) {
+  async getQueryStats(scalingoApp) {
     const { result } = await scalingoApi.getQueryStats(scalingoApp);
     return result || [];
   },

--- a/tests/integration/infrastructure/database-stats-repository_test.js
+++ b/tests/integration/infrastructure/database-stats-repository_test.js
@@ -1,24 +1,94 @@
 const {
   getRunningQueries,
+  getQueryStats,
 } = require('../../../lib/infrastructure/database-stats-repository');
-const { expect, sinon } = require('../../test-helper');
+const { expect, sinon, nock } = require('../../test-helper');
 
 describe('database-stats-repository', () => {
   describe('#getRunningQueries', () => {
     it('should call scalingoApi.getRunningQueries and return result', async () => {
-          // given
-          const scalingoApp = 'application';
-          const  getRunningQueriesStub = sinon.stub();
-          const expected = { queriesCount: 1, longQueriesCount: 0};
-          getRunningQueriesStub.resolves(expected);
-          const scalingoApi = { getRunningQueries : getRunningQueriesStub};
+      // given
+      const scalingoApp = 'application';
+      const getRunningQueriesStub = sinon.stub();
+      const expected = { queriesCount: 1, longQueriesCount: 0 };
+      getRunningQueriesStub.resolves(expected);
+      const scalingoApi = { getRunningQueries: getRunningQueriesStub };
 
-          // when
-          const response = await getRunningQueries(scalingoApi, scalingoApp);
+      // when
+      const response = await getRunningQueries(scalingoApi, scalingoApp);
 
-          // then
-          expect(getRunningQueriesStub).to.have.been.calledOnceWithExactly(scalingoApp);
-          expect(response).to.deep.equal(expected);
+      // then
+      expect(getRunningQueriesStub).to.have.been.calledOnceWithExactly(
+        scalingoApp
+      );
+      expect(response).to.deep.equal(expected);
+    });
+  });
+
+  describe('#getQueryStats', () => {
+    it('should call scalingoApi.getQueryStats and return result', async () => {
+      // given
+      const queryStats = [
+        {
+          user_id: 1000,
+          query: 'SELECT * FROM users',
+          calls: 14512,
+          rows: 1500,
+          total_time: 1837.1,
+          min_time: 10.2,
+          max_time: 13.5,
+          mean_time: 10.6,
+          std_dev: 1.1,
+        },
+        {
+          user_id: 2000,
+          query: 'SELECT * FROM database',
+          calls: 24512,
+          rows: 2500,
+          total_time: 21837.1,
+          min_time: 20.2,
+          max_time: 23.5,
+          mean_time: 20.6,
+          std_dev: 2.1,
+        },
+      ];
+
+      tokenNock = nock(`https://auth.scalingo.com`)
+        .post('/v1/tokens/exchange')
+        .reply(200, {
+          token: 'myfaketoken',
+        });
+
+      addonIdNock = nock(`https://api.REGION.scalingo.com`)
+        .get('/v1/apps/application-1/addons')
+        .reply(200, {
+          addons: [{ id: 'addonid', addon_provider: { id: 'postgresql' } }],
+        });
+
+      addonTokenNock = nock('https://api.REGION.scalingo.com')
+        .post('/v1/apps/application-1/addons/addonid/token')
+        .reply(200, {
+          addon: { token: 'myfaketoken' },
+        });
+
+      statsNock = nock(`https://db-api.REGION.scalingo.com`)
+        .post('/api/databases/addonid/action')
+        .reply(200, {
+          ok: 1,
+          result: queryStats,
+        });
+
+      const scalingoApp = 'application-1';
+
+      // when
+      const response = await getQueryStats(scalingoApp);
+
+      // then
+      expect(tokenNock.calledOnceWithExactly);
+      expect(addonIdNock.calledOnceWithExactly);
+      expect(addonTokenNock.calledOnceWithExactly);
+      expect(statsNock.calledOnceWithExactly);
+      expect(response).to.deep.equal(queryStats);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans #21, l'appel à getQueryStats a été modifié par erreur.
Cela empêche son fonctionnement

## :robot: Solution
Corriger l'appel.
Rajouter des tests automatisés pour éviter les futures régressions.

## :rainbow: Remarques
Les nock de scalingo pourraient être ajoutés au test-helper pour resservir ailleurs

## :100: Pour tester
`npm test` 😏
