### PR TITLE
[BUGFIX] Le conteneur s'arrête si Scalingo renvoie une erreur

### DIFF
--- a/lib/application/task-cache-hit.js
+++ b/lib/application/task-cache-hit.js
@@ -25,11 +25,9 @@ const logCacheHits = async () => {
       const cacheHit = await getCacheHit(connectionString);
       logger.info({ event, app: scalingoApp, data: { cacheHit } });
     } catch (error) {
-      logger.error({
-        task: 'cache-hit',
+      logger.error(error, {
+        task: 'cache-hit-ratio',
         app: scalingoApp,
-        message: error.message.slice(0, 1000),
-        error: error.response.data.error,
       });
     }
   }

--- a/lib/application/task-cache-hit.js
+++ b/lib/application/task-cache-hit.js
@@ -20,9 +20,18 @@ const getCacheHit = async (connectionString) => {
 const logCacheHits = async () => {
   const event = 'cache-hit-ratio';
   for (const scalingoApp of SCALINGO_APPS) {
-    const connectionString = await databaseStatsRepository.getDbConnectionString(scalingoApp);
-    const cacheHit = await getCacheHit(connectionString);
-    logger.info({ event, app: scalingoApp, data: { cacheHit } });
+    try {
+      const connectionString = await databaseStatsRepository.getDbConnectionString(scalingoApp);
+      const cacheHit = await getCacheHit(connectionString);
+      logger.info({ event, app: scalingoApp, data: { cacheHit } });
+    } catch (error) {
+      logger.error({
+        task: 'cache-hit',
+        app: scalingoApp,
+        message: error.message.slice(0, 1000),
+        error: error.response.data.error,
+      });
+    }
   }
 };
 

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -4,19 +4,23 @@ const { SCALINGO_APPS } = require('../../config');
 
 async function taskMetrics() {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
-    const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApp);
-    const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
+    try {
+      const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApp);
+      const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
 
-    const stats = await databaseStatsRepository.getCPULoad(metrics, leaderNodeId);
+      const stats = await databaseStatsRepository.getCPULoad(metrics, leaderNodeId);
 
-    logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
-    logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
+      logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
+      logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
 
-    const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
-    logger.info({ event: 'db-disk', app: scalingoApp, data: disk });
+      const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
+      logger.info({ event: 'db-disk', app: scalingoApp, data: disk });
 
-    const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApp, leaderNodeId);
-    logger.info({ event: 'db-diskio', app: scalingoApp, data: diskio });
+      const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApp, leaderNodeId);
+      logger.info({ event: 'db-diskio', app: scalingoApp, data: diskio });
+    } catch (error) {
+      logger.error({ task: 'metrics', message: error.message.slice(0, 1000), error: error.response.data.error });
+    }
   });
 }
 

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -19,7 +19,10 @@ async function taskMetrics() {
       const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApp, leaderNodeId);
       logger.info({ event: 'db-diskio', app: scalingoApp, data: diskio });
     } catch (error) {
-      logger.error({ task: 'metrics', message: error.message.slice(0, 1000), error: error.response.data.error });
+      logger.error(error, {
+        task: 'metrics',
+        app: scalingoApp,
+      });
     }
   });
 }

--- a/lib/application/task-progress.js
+++ b/lib/application/task-progress.js
@@ -7,24 +7,30 @@ const PROGRESS_VIEW_PREFIX = 'pg_stat_progress_';
 
 const taskProgress = async () => {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
-    const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
-
-    const client = new Client(dbURL);
-
     try {
-      await client.connect();
+      const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
 
-      const { rows: views } = await client.query(
-        `SELECT relname FROM pg_class WHERE relname LIKE '${PROGRESS_VIEW_PREFIX}%'`
-      );
+      const client = new Client(dbURL);
 
-      for (const { relname: view } of views) {
-        const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
-        const { rows: entries } = await client.query(`SELECT * from ${view}`);
-        entries.forEach((entry) => logger.info({ event: 'progress', app: scalingoApp, data: { operation, ...entry } }));
+      try {
+        await client.connect();
+
+        const { rows: views } = await client.query(
+          `SELECT relname FROM pg_class WHERE relname LIKE '${PROGRESS_VIEW_PREFIX}%'`
+        );
+
+        for (const { relname: view } of views) {
+          const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
+          const { rows: entries } = await client.query(`SELECT * from ${view}`);
+          entries.forEach((entry) =>
+            logger.info({ event: 'progress', app: scalingoApp, data: { operation, ...entry } })
+          );
+        }
+      } finally {
+        await client.end();
       }
-    } finally {
-      await client.end();
+    } catch (error) {
+      logger.error({ task: 'progress', message: error.message.slice(0, 1000), error: error.response.data.error });
     }
   });
 };

--- a/lib/application/task-progress.js
+++ b/lib/application/task-progress.js
@@ -30,7 +30,10 @@ const taskProgress = async () => {
         await client.end();
       }
     } catch (error) {
-      logger.error({ task: 'progress', message: error.message.slice(0, 1000), error: error.response.data.error });
+      logger.error(error, {
+        task: 'progress',
+        app: scalingoApp,
+      });
     }
   });
 };

--- a/lib/application/task-queries-metric.js
+++ b/lib/application/task-queries-metric.js
@@ -2,20 +2,19 @@ const logger = require('../infrastructure/logger');
 const { SCALINGO_APPS } = require('../../config');
 
 async function task(databaseStatsRepository, scalingoApi) {
-  SCALINGO_APPS.forEach(async (applicationName) => {
+  SCALINGO_APPS.forEach(async (scalingoApp) => {
     try {
-      const data = await databaseStatsRepository.getQueriesMetric(scalingoApi, applicationName);
+      const data = await databaseStatsRepository.getQueriesMetric(scalingoApi, scalingoApp);
 
       logger.info({
         event: 'db-queries-metric',
-        app: applicationName,
+        app: scalingoApp,
         data,
       });
     } catch (error) {
-      logger.error({
+      logger.error(error, {
         task: 'db-queries-metric',
-        message: error.message.slice(0, 1000),
-        error: error.response.data.error,
+        app: scalingoApp,
       });
     }
   });

--- a/lib/application/task-queries-metric.js
+++ b/lib/application/task-queries-metric.js
@@ -3,13 +3,21 @@ const { SCALINGO_APPS } = require('../../config');
 
 async function task(databaseStatsRepository, scalingoApi) {
   SCALINGO_APPS.forEach(async (applicationName) => {
-    const data = await databaseStatsRepository.getQueriesMetric(scalingoApi, applicationName);
+    try {
+      const data = await databaseStatsRepository.getQueriesMetric(scalingoApi, applicationName);
 
-    logger.info({
-      event: 'db-queries-metric',
-      app: applicationName,
-      data,
-    });
+      logger.info({
+        event: 'db-queries-metric',
+        app: applicationName,
+        data,
+      });
+    } catch (error) {
+      logger.error({
+        task: 'db-queries-metric',
+        message: error.message.slice(0, 1000),
+        error: error.response.data.error,
+      });
+    }
   });
 }
 

--- a/lib/application/task-response-time.js
+++ b/lib/application/task-response-time.js
@@ -21,7 +21,10 @@ const taskResponseTime = async () => {
 
       client.end();
     } catch (error) {
-      logger.error({ task: 'response-time', message: error.message.slice(0, 1000), error: error.response.data.error });
+      logger.error(error, {
+        task: 'response-time',
+        app: scalingoApp,
+      });
     }
   });
 };

--- a/lib/application/task-response-time.js
+++ b/lib/application/task-response-time.js
@@ -5,20 +5,24 @@ const { SCALINGO_APPS, RESPONSE_TIME_QUERY } = require('../../config');
 
 const taskResponseTime = async () => {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
-    const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
+    try {
+      const dbURL = await databaseStatsRepository.getDbConnectionString(scalingoApp);
 
-    const client = new Client(dbURL);
+      const client = new Client(dbURL);
 
-    client.connect();
-    await preventWrites(client);
+      client.connect();
+      await preventWrites(client);
 
-    const startTime = Date.now();
-    await client.query(RESPONSE_TIME_QUERY);
-    const duration = Date.now() - startTime;
+      const startTime = Date.now();
+      await client.query(RESPONSE_TIME_QUERY);
+      const duration = Date.now() - startTime;
 
-    logger.info({ event: 'response-time-millis', app: scalingoApp, data: { duration } });
+      logger.info({ event: 'response-time-millis', app: scalingoApp, data: { duration } });
 
-    client.end();
+      client.end();
+    } catch (error) {
+      logger.error({ task: 'response-time', message: error.message.slice(0, 1000), error: error.response.data.error });
+    }
   });
 };
 

--- a/lib/application/task-statements.js
+++ b/lib/application/task-statements.js
@@ -11,7 +11,10 @@ async function task() {
 
       await databaseStatsRepository.resetQueryStats(scalingoApp);
     } catch (error) {
-      logger.error({ task: 'statements', message: error.message.slice(0, 1000), error: error.response.data.error });
+      logger.error(error, {
+        task: 'statements',
+        app: scalingoApp,
+      });
     }
   });
 }

--- a/lib/application/task-statements.js
+++ b/lib/application/task-statements.js
@@ -4,11 +4,15 @@ const { SCALINGO_APPS } = require('../../config');
 
 async function task() {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
-    const queryStats = await databaseStatsRepository.getQueryStats(scalingoApp);
+    try {
+      const queryStats = await databaseStatsRepository.getQueryStats(scalingoApp);
 
-    queryStats.forEach((query) => logger.info({ event: 'db-query-stats', app: scalingoApp, data: query }));
+      queryStats.forEach((query) => logger.info({ event: 'db-query-stats', app: scalingoApp, data: query }));
 
-    await databaseStatsRepository.resetQueryStats(scalingoApp);
+      await databaseStatsRepository.resetQueryStats(scalingoApp);
+    } catch (error) {
+      logger.error({ task: 'statements', message: error.message.slice(0, 1000), error: error.response.data.error });
+    }
   });
 }
 

--- a/lib/infrastructure/logger.js
+++ b/lib/infrastructure/logger.js
@@ -2,4 +2,7 @@ module.exports = {
   info({ event, app, data }) {
     console.log(JSON.stringify({ event, app, data }));
   },
+  error({ task, error, message, app }) {
+    console.log(JSON.stringify({ status: 'ERROR', message, error, task, app }));
+  },
 };

--- a/lib/infrastructure/logger.js
+++ b/lib/infrastructure/logger.js
@@ -2,7 +2,10 @@ module.exports = {
   info({ event, app, data }) {
     console.log(JSON.stringify({ event, app, data }));
   },
-  error({ task, error, message, app }) {
-    console.log(JSON.stringify({ status: 'ERROR', message, error, task, app }));
+  error(error, { task, app }) {
+    const STACKTRACE_EXTRACT_LENGTH = 1000;
+    const errorMessage = error.message.slice(0, STACKTRACE_EXTRACT_LENGTH);
+    const errorDescription = error.response.data.error;
+    console.log(JSON.stringify({ status: 'ERROR', errorMessage, errorDescription, task, app }));
   },
 };

--- a/sample.env
+++ b/sample.env
@@ -87,7 +87,7 @@ FT_PROGRESS=yes
 # presence: optional
 # type: text
 # value: yes to activate
-FT_RUNNING_QUERIES=yes
+FT_QUERIES_METRIC=yes
 
 # Execution periodicity (for node-cron library, in a cron-like pattern)
 # Cron patterns have five fields, and 1 minute as the finest granularity

--- a/sample.env
+++ b/sample.env
@@ -81,13 +81,13 @@ FT_RESPONSE_TIME=yes
 # value: yes to activate
 FT_PROGRESS=yes
 
-# Enable queries metrics
+
+# Enable running queries monitoring
 #
 # presence: optional
 # type: text
 # value: yes to activate
-FT_QUERIES_METRIC=yes
-
+FT_RUNNING_QUERIES=yes
 
 # Execution periodicity (for node-cron library, in a cron-like pattern)
 # Cron patterns have five fields, and 1 minute as the finest granularity

--- a/tests/integration/application/task-cache-hit_test.js
+++ b/tests/integration/application/task-cache-hit_test.js
@@ -26,7 +26,6 @@ describe('#logCacheHits', function () {
     try {
       await logCacheHits();
     } catch (error) {
-      console.log(error);
       hasThrown = true;
     }
     // then

--- a/tests/integration/application/task-cache-hit_test.js
+++ b/tests/integration/application/task-cache-hit_test.js
@@ -1,5 +1,5 @@
-const { expect } = require('chai');
-const { getCacheHit } = require('../../../lib/application/task-cache-hit');
+const { expect, nock } = require('../../test-helper');
+const { getCacheHit, logCacheHits } = require('../../../lib/application/task-cache-hit');
 const { TEST_DATABASE_URL: connexionString } = require('../../../config');
 
 describe('#getCacheHit', function () {
@@ -11,5 +11,25 @@ describe('#getCacheHit', function () {
     expect(result).to.be.a('number');
     expect(result).to.be.at.least(0);
     expect(result).to.be.at.most(100);
+  });
+});
+
+describe('#logCacheHits', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await logCacheHits();
+    } catch (error) {
+      console.log(error);
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
   });
 });

--- a/tests/integration/application/task-metrics_test.js
+++ b/tests/integration/application/task-metrics_test.js
@@ -1,0 +1,21 @@
+const { expect, nock } = require('../../test-helper');
+const taskMetrics = require('../../../lib/application/task-metrics');
+
+describe('#taskMetrics', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await taskMetrics();
+    } catch (error) {
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
+  });
+});

--- a/tests/integration/application/task-progress_test.js
+++ b/tests/integration/application/task-progress_test.js
@@ -1,0 +1,21 @@
+const { expect, nock } = require('../../test-helper');
+const taskProgress = require('../../../lib/application/task-progress');
+
+describe('#taskProgress', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await taskProgress();
+    } catch (error) {
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
+  });
+});

--- a/tests/integration/application/task-queries-metric_test.js
+++ b/tests/integration/application/task-queries-metric_test.js
@@ -1,5 +1,5 @@
 const taskQueriesMetric = require('../../../lib/application/task-queries-metric');
-const { expect, sinon } = require('../../test-helper');
+const { expect, sinon, nock } = require('../../test-helper');
 
 describe('task-queries-metric', function () {
   it('should call queries metric once for each application', async function () {
@@ -19,5 +19,31 @@ describe('task-queries-metric', function () {
     expect(getQueriesMetricStub.firstCall.args[1]).to.equal('application-1');
     expect(getQueriesMetricStub.secondCall.args[0]).to.equal(scalingoApi);
     expect(getQueriesMetricStub.secondCall.args[1]).to.equal('application-2');
+  });
+});
+describe('#task-queries-metric', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // given
+    const getQueriesMetricStub = sinon.stub();
+    const expected = { queriesCount: 1, longQueriesCount: 0 };
+    getQueriesMetricStub.resolves(expected);
+    const databaseStatsRepository = {
+      getRunningQueries: getQueriesMetricStub,
+    };
+    const scalingoApi = sinon.stub();
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await taskQueriesMetric.run(databaseStatsRepository, scalingoApi);
+    } catch (error) {
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
   });
 });

--- a/tests/integration/application/task-response-time_test.js
+++ b/tests/integration/application/task-response-time_test.js
@@ -1,0 +1,21 @@
+const { expect, nock } = require('../../test-helper');
+const taskResponseTime = require('../../../lib/application/task-response-time');
+
+describe('#taskResponseTime', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await taskResponseTime();
+    } catch (error) {
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
+  });
+});

--- a/tests/integration/application/task-statements_test.js
+++ b/tests/integration/application/task-statements_test.js
@@ -1,0 +1,21 @@
+const { expect, nock } = require('../../test-helper');
+const task = require('../../../lib/application/task-statements');
+
+describe('#task', function () {
+  it('should not throw an error when API Scalingo fails', async function () {
+    let hasThrown = false;
+    // when
+    nock(`https://auth.scalingo.com`).persist().post('/v1/tokens/exchange').reply(401, {
+      token: 'myfaketoken',
+      error: 'Invalid credentials',
+    });
+
+    try {
+      await task();
+    } catch (error) {
+      hasThrown = true;
+    }
+    // then
+    expect(hasThrown).to.be.false;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les tasks peuvent faire crasher l'app sur l'appel à l'API de Scalingo 

## :robot: Solution
Ajouter des try catch et logger les erreurs

## :100: Pour tester

Ne pas mettre de token scalingo

et exécuter l'app avec la commande : 
```sh
npm run metrics
```

