### PR TITLE
Suppression de l'évènement leader-cpu

### DIFF
--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -8,9 +8,6 @@ async function taskMetrics() {
       const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApp);
       const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
 
-      const stats = await databaseStatsRepository.getCPULoad(metrics, leaderNodeId);
-
-      logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
       logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
 
       const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -1,10 +1,6 @@
 const scalingoApi = require('./scalingo-api');
 
 module.exports = {
-  async getCPULoad(dbMetrics, leaderNodeId) {
-    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, leaderNodeId);
-  },
-
   getDatabaseLeaderNodeId(scalingoApp) {
     return _getDatabaseLeaderNodeId(scalingoApp);
   },
@@ -49,9 +45,4 @@ module.exports = {
 async function _getDatabaseLeaderNodeId(scalingoApp) {
   const instancesStatus = await scalingoApi.getInstancesStatus(scalingoApp);
   return instancesStatus.filter(({ type, role }) => type === 'db-node' && role === 'leader').map(({ id }) => id)[0];
-}
-
-function _extractCPUUsageForDatabaseLeaderNode(dbMetrics, node) {
-  const { instance_id, cpu } = dbMetrics.instances_metrics[node];
-  return { instance_id: instance_id, cpu: cpu.usage_in_percents };
 }


### PR DESCRIPTION
## :unicorn: Problème
L'évenement `leader-cpu` est redondant avec `db-metrics`

## :robot: Solution
Supprimer les informations liées à cet événement

## :100: Pour tester
Lancer l'application avec le FT `FT_METRICS` activé, verifier que `leader-cpu` n'apparait plus
