### PR TITLE
[FEATURE] Monitorer les métriques du leader BDD

### DIFF
--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -10,7 +10,14 @@ async function taskMetrics() {
 
       const leaderMetrics = databaseStatsRepository.getInstanceMetrics(metrics, leaderNodeId);
 
-      logger.info({ event: 'db-metrics', app: scalingoApp, data: { ...metrics, leader_metrics: leaderMetrics } });
+      logger.info({
+        event: 'db-metrics',
+        app: scalingoApp,
+        data: {
+          leader_metrics: { ...leaderMetrics, cpu: leaderMetrics.cpu.usage_in_percents },
+          database_stats: metrics.database_stats,
+        },
+      });
 
       const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
       logger.info({ event: 'db-disk', app: scalingoApp, data: disk });

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -8,10 +8,9 @@ async function taskMetrics() {
       const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApp);
       const metrics = await databaseStatsRepository.getDBMetrics(scalingoApp);
 
-      const stats = await databaseStatsRepository.getCPULoad(metrics, leaderNodeId);
+      const leaderMetrics = databaseStatsRepository.getInstanceMetrics(metrics, leaderNodeId);
 
-      logger.info({ event: 'leader-cpu', app: scalingoApp, data: stats });
-      logger.info({ event: 'db-metrics', app: scalingoApp, data: metrics });
+      logger.info({ event: 'db-metrics', app: scalingoApp, data: { ...metrics, leader_metrics: leaderMetrics } });
 
       const disk = await databaseStatsRepository.getDBDisk(scalingoApp, leaderNodeId);
       logger.info({ event: 'db-disk', app: scalingoApp, data: disk });

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -1,8 +1,8 @@
 const scalingoApi = require('./scalingo-api');
 
 module.exports = {
-  async getCPULoad(dbMetrics, leaderNodeId) {
-    return _extractCPUUsageForDatabaseLeaderNode(dbMetrics, leaderNodeId);
+  getInstanceMetrics(dbMetrics, instanceId) {
+    return dbMetrics.instances_metrics[instanceId];
   },
 
   getDatabaseLeaderNodeId(scalingoApp) {
@@ -49,9 +49,4 @@ module.exports = {
 async function _getDatabaseLeaderNodeId(scalingoApp) {
   const instancesStatus = await scalingoApi.getInstancesStatus(scalingoApp);
   return instancesStatus.filter(({ type, role }) => type === 'db-node' && role === 'leader').map(({ id }) => id)[0];
-}
-
-function _extractCPUUsageForDatabaseLeaderNode(dbMetrics, node) {
-  const { instance_id, cpu } = dbMetrics.instances_metrics[node];
-  return { instance_id: instance_id, cpu: cpu.usage_in_percents };
 }


### PR DESCRIPTION
## :unicorn: Problème
Les informations contenues dans l'événement `db-metrics` ne permettent pas de connaître le leader, et le format n'est de toute façon pas idéal pour datadog. De plus, on envoie l'information du CPU du leader dans un événement séparé `leader-cpu`. 

## :robot: Solution
Rajouter toutes les métrqiues du leader BDD dans un évènement `db-metrics`.

## :rainbow: Remarques
Supprimer l'évènement `leader-cpu`.

## :100: Pour tester
Activer les métriques 
```shell
scalingo --region osc-fr1 -app pix-db-stats-review-pr33 env-set FT_METRICS=yes
scalingo --region osc-fr1 -app pix-db-stats-review-pr33 env-set METRICS_SCHEDULE=$EACH_SECOND
scalingo --region osc-fr1 -app pix-db-stats-review-pr33 restart
```
Générer de l'activité avec https://github.com/1024pix/pix/pull/5168

Consulter les métriques de la BDD de  [pix-api-integration](https://db-osc-fr1.scalingo.com/dashboard/636516e1164b6ea609f82c42/metrics)

Consulter les logs
```shell
scalingo --region osc-fr1 -app pix-db-stats-review-pr33 logs --follow | grep db-metrics
```

Vérifier que les valeurs correspondent 
