### PR TITLE
[BUGFIX] Ne crashe pas si l'erreur n'a pas le format attendu

### DIFF
--- a/lib/infrastructure/logger.js
+++ b/lib/infrastructure/logger.js
@@ -3,9 +3,7 @@ module.exports = {
     console.log(JSON.stringify({ event, app, database, data }));
   },
   error(error, { task, app }) {
-    const STACKTRACE_EXTRACT_LENGTH = 1000;
-    const errorMessage = error.message.slice(0, STACKTRACE_EXTRACT_LENGTH);
-    const errorDescription = error.response.data.error;
-    console.log(JSON.stringify({ status: 'ERROR', errorMessage, errorDescription, task, app }));
+    console.error(error);
+    console.log(JSON.stringify({ status: 'ERROR', message: error.message, task, app }));
   },
 };


### PR DESCRIPTION
## :unicorn: Problème
Si l'erreur n'a pas le format attendu avec `response.data.error`, l'appli crash.

## :robot: Solution
Pour éviter de crasher et perdre la raison de l'erreur initiale, en faire le moins possible.

## :100: Pour tester
Pas évident ...
