### PR TITLE
[FEATURE] Envoi un seul événement db-metrics avec les informations du leader, son disque et les IO

### DIFF
--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -9,26 +9,14 @@ async function taskMetrics() {
       const databases = await databaseStatsRepository.getAvailableDatabases(scalingoApi, scalingoApp);
       await Promise.all(
         databases.map(async ({ name, id: addonId }) => {
-          const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
           const metrics = await databaseStatsRepository.getDBMetrics(scalingoApi, scalingoApp, addonId);
-
-          const leaderMetrics = databaseStatsRepository.getInstanceMetrics(metrics, leaderNodeId);
 
           logger.info({
             event: 'db-metrics',
             app: scalingoApp,
             database: name,
-            data: {
-              leader_metrics: { ...leaderMetrics, cpu: leaderMetrics.cpu.usage_in_percents },
-              database_stats: metrics.database_stats,
-            },
+            data: metrics,
           });
-
-          const disk = await databaseStatsRepository.getDBDisk(scalingoApi, scalingoApp, addonId, leaderNodeId);
-          logger.info({ event: 'db-disk', app: scalingoApp, database: name, data: disk });
-
-          const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApi, scalingoApp, addonId, leaderNodeId);
-          logger.info({ event: 'db-diskio', app: scalingoApp, database: name, data: diskio });
         })
       );
     } catch (error) {

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -16,26 +16,21 @@ module.exports = {
       });
   },
 
-  getInstanceMetrics(dbMetrics, instanceId) {
-    return dbMetrics.instances_metrics[instanceId];
-  },
-
-  getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId) {
-    return _getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
-  },
-
-  getDBMetrics(scalingoApi, scalingoApp, addonId) {
-    return scalingoApi.getDbMetrics(scalingoApp, addonId);
-  },
-
-  async getDBDisk(scalingoApi, scalingoApp, addonId, leaderNodeId) {
+  async getDBMetrics(scalingoApi, scalingoApp, addonId) {
+    const leaderNodeId = await _getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
+    const metrics = await scalingoApi.getDbMetrics(scalingoApp, addonId);
+    const leaderMetrics = metrics.instances_metrics[leaderNodeId];
     const { disk_used, disk_total } = await scalingoApi.getDbDisk(scalingoApp, addonId, leaderNodeId);
-    return { disk_total, disk_used };
-  },
-
-  async getDBDiskIO(scalingoApi, scalingoApp, addonId, leaderNodeId) {
     const { diskio_reads, diskio_writes } = await scalingoApi.getDbDiskIO(scalingoApp, addonId, leaderNodeId);
-    return { diskio_reads, diskio_writes };
+    return {
+      leader_metrics: {
+        ...leaderMetrics,
+        cpu: leaderMetrics.cpu.usage_in_percents,
+        disk: { used: disk_used, total: disk_total },
+        diskio: { reads: diskio_reads, writes: diskio_writes },
+      },
+      database_stats: metrics.database_stats,
+    };
   },
 
   getPgConnectionString(scalingoApp) {

--- a/tests/integration/infrastructure/database-stats-repository_test.js
+++ b/tests/integration/infrastructure/database-stats-repository_test.js
@@ -3,9 +3,6 @@ const {
   getDBMetrics,
   getPgQueriesMetric,
   getPgQueryStats,
-  getDatabaseLeaderNodeId,
-  getDBDisk,
-  getDBDiskIO,
 } = require('../../../lib/infrastructure/database-stats-repository');
 const { expect, sinon, nock } = require('../../test-helper');
 
@@ -49,11 +46,29 @@ describe('database-stats-repository', function () {
   });
 
   describe('#getDbMetrics', function () {
-    it('should call scalingoApi.getDbMetrics and return them', async function () {
+    it('should return global metrics and specific metrics from the leader', async function () {
       // given
       const scalingoApp = 'my-application';
       const addonId = 'my-addon-id';
       const expectedMetrics = {
+        database_stats: {
+          data_size: 11044896,
+        },
+        leader_metrics: {
+          cpu: 4,
+          memory: {
+            memory: 156426240,
+            memory_max: 222314496,
+            memory_limit: 536870912,
+            swap: 20480,
+            swap_max: 0,
+            swap_limit: 536870912,
+          },
+          disk: { total: 120, used: 10 },
+          diskio: { reads: 120, writes: 10 },
+        },
+      };
+      const getDbMetricsStub = sinon.stub().resolves({
         cpu_usage: 0,
         memory: {
           memory: 156426240,
@@ -66,99 +81,66 @@ describe('database-stats-repository', function () {
         database_stats: {
           data_size: 11044896,
         },
+        instances_metrics: {
+          'instance-leader': {
+            memory: {
+              memory: 156426240,
+              memory_max: 222314496,
+              memory_limit: 536870912,
+              swap: 20480,
+              swap_max: 0,
+              swap_limit: 536870912,
+            },
+            cpu: {
+              usage_in_percents: 4,
+            },
+          },
+        },
+      });
+      const getInstancesStatusStub = sinon.stub().resolves([
+        {
+          id: 'gateway',
+          type: 'gateway',
+          status: 'running',
+          role: '',
+        },
+        {
+          id: 'instance-leader',
+          type: 'db-node',
+          status: 'running',
+          role: 'leader',
+        },
+        {
+          id: 'instance-follower1',
+          type: 'db-node',
+          status: 'running',
+          role: 'follower',
+        },
+        {
+          id: 'instance-follower2',
+          type: 'db-node',
+          status: 'running',
+          role: 'follower',
+        },
+      ]);
+      const getDbDiskStub = sinon.stub().resolves({ disk_total: 120, disk_used: 10 });
+      const getDbDiskIOStub = sinon.stub().resolves({ diskio_reads: 120, diskio_writes: 10 });
+      const scalingoApi = {
+        getDbMetrics: getDbMetricsStub,
+        getInstancesStatus: getInstancesStatusStub,
+        getDbDisk: getDbDiskStub,
+        getDbDiskIO: getDbDiskIOStub,
       };
-      const getDbMetricsStub = sinon.stub().resolves(expectedMetrics);
-      const scalingoApi = { getDbMetrics: getDbMetricsStub };
 
       // when
       const metrics = await getDBMetrics(scalingoApi, scalingoApp, addonId);
 
       // then
       expect(getDbMetricsStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId);
-      expect(metrics).to.eql(expectedMetrics);
-    });
-  });
-
-  describe('#getDatabaseLeaderNodeId', function () {
-    it('should call scalingoApi.getInstanceStatus and filter result', async function () {
-      // given
-      const scalingoApp = 'my-application';
-      const addonId = 'my-addon-id';
-      const instanceStatus = [
-        {
-          id: '5b8a26d4-160b-484a-be7f-258ae4cad80d',
-          type: 'gateway',
-          status: 'running',
-          role: '',
-        },
-        {
-          id: 'a541dfb5-1fa6-40d7-87de-159ab721322c',
-          type: 'db-node',
-          status: 'running',
-          role: 'leader',
-        },
-        {
-          id: '9597fb2e-b3ee-4917-bca8-d7c4333c8cc6',
-          type: 'db-node',
-          status: 'running',
-          role: 'follower',
-        },
-        {
-          id: '33067baf-807c-4a9a-a966-25008945968b',
-          type: 'db-node',
-          status: 'running',
-          role: 'follower',
-        },
-      ];
-      const getInstancesStatusStub = sinon.stub().resolves(instanceStatus);
-      const scalingoApi = { getInstancesStatus: getInstancesStatusStub };
-
-      // when
-      const metrics = await getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
-
-      // then
       expect(getInstancesStatusStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId);
-      expect(metrics).to.eql('a541dfb5-1fa6-40d7-87de-159ab721322c');
-    });
-  });
-
-  describe('#getDBDisk', function () {
-    it('should call scalingoApi.getDbDisk and returns disk_total and disk_used', async function () {
-      // given
-      const scalingoApp = 'application';
-      const addonId = 'my-addon-id';
-      const leaderNodeId = 'my-leader-node-id';
-      const getDbDiskStub = sinon.stub();
-      const expected = { disk_total: 120, disk_used: 10 };
-      getDbDiskStub.resolves(expected);
-      const scalingoApi = { getDbDisk: getDbDiskStub };
-
-      // when
-      const response = await getDBDisk(scalingoApi, scalingoApp, addonId, leaderNodeId);
-
-      // then
-      expect(getDbDiskStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId, leaderNodeId);
-      expect(response).to.deep.equal(expected);
-    });
-  });
-
-  describe('#getDBDiskIo', function () {
-    it('should call scalingoApi.getDbDiskIO and returns diskio_reads and diskio_writes', async function () {
-      // given
-      const scalingoApp = 'application';
-      const addonId = 'my-addon-id';
-      const leaderNodeId = 'my-leader-node-id';
-      const getDbDiskIOStub = sinon.stub();
-      const expected = { diskio_reads: 120, diskio_writes: 10 };
-      getDbDiskIOStub.resolves(expected);
-      const scalingoApi = { getDbDiskIO: getDbDiskIOStub };
-
-      // when
-      const response = await getDBDiskIO(scalingoApi, scalingoApp, addonId, leaderNodeId);
-
-      // then
-      expect(getDbDiskIOStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId, leaderNodeId);
-      expect(response).to.deep.equal(expected);
+      expect(getDbDiskStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId, 'instance-leader');
+      expect(getDbDiskIOStub).to.have.been.calledOnceWithExactly(scalingoApp, addonId, 'instance-leader');
+      expect(metrics).to.eql(expectedMetrics);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Nous avons actuellement 3 événements pour récupérer les métriques de la base de données. L'événement `db-metrics` renvoit les informations générales du serveur et les informations CPU et mémoire du leader. Les événements `db-disk` et `db-diskio` renvoient les informations de disque et d'IOs  du leader. 

## :robot: Solution
Fusion des 3 événements pour rajouter les informations de disk et d'IO dans l'événement `db-metrics`, dans la partie `leader_metrics`.

## :rainbow: Remarques
Plus simple a tester !

## :100: Pour tester
1. Activer FT_METRICS=true
2. Regarder dans les logs l'événement db-metrics et voir les informations de disk et de diskio.
