### PR TITLE
[BUGFIX] Corrige le crash en cas d'erreurs lors de la récupération des metrics

### DIFF
--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -7,28 +7,30 @@ async function taskMetrics() {
   SCALINGO_APPS.forEach(async (scalingoApp) => {
     try {
       const databases = await databaseStatsRepository.getAvailableDatabases(scalingoApi, scalingoApp);
-      databases.forEach(async ({ name, id: addonId }) => {
-        const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
-        const metrics = await databaseStatsRepository.getDBMetrics(scalingoApi, scalingoApp, addonId);
+      await Promise.all(
+        databases.map(async ({ name, id: addonId }) => {
+          const leaderNodeId = await databaseStatsRepository.getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
+          const metrics = await databaseStatsRepository.getDBMetrics(scalingoApi, scalingoApp, addonId);
 
-        const leaderMetrics = databaseStatsRepository.getInstanceMetrics(metrics, leaderNodeId);
+          const leaderMetrics = databaseStatsRepository.getInstanceMetrics(metrics, leaderNodeId);
 
-        logger.info({
-          event: 'db-metrics',
-          app: scalingoApp,
-          database: name,
-          data: {
-            leader_metrics: { ...leaderMetrics, cpu: leaderMetrics.cpu.usage_in_percents },
-            database_stats: metrics.database_stats,
-          },
-        });
+          logger.info({
+            event: 'db-metrics',
+            app: scalingoApp,
+            database: name,
+            data: {
+              leader_metrics: { ...leaderMetrics, cpu: leaderMetrics.cpu.usage_in_percents },
+              database_stats: metrics.database_stats,
+            },
+          });
 
-        const disk = await databaseStatsRepository.getDBDisk(scalingoApi, scalingoApp, addonId, leaderNodeId);
-        logger.info({ event: 'db-disk', app: scalingoApp, database: name, data: disk });
+          const disk = await databaseStatsRepository.getDBDisk(scalingoApi, scalingoApp, addonId, leaderNodeId);
+          logger.info({ event: 'db-disk', app: scalingoApp, database: name, data: disk });
 
-        const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApi, scalingoApp, addonId, leaderNodeId);
-        logger.info({ event: 'db-diskio', app: scalingoApp, database: name, data: diskio });
-      });
+          const diskio = await databaseStatsRepository.getDBDiskIO(scalingoApi, scalingoApp, addonId, leaderNodeId);
+          logger.info({ event: 'db-diskio', app: scalingoApp, database: name, data: diskio });
+        })
+      );
     } catch (error) {
       logger.error(error, {
         task: 'metrics',


### PR DESCRIPTION
## :unicorn: Problème
Si une méthode d'API lors de la récupération des metriques renvoit une erreur, l'exception n'est pas récupéré car le bloc de code n'est pas attendu via un await.

## :robot: Solution
Ajouter un Promise.all et rajouter un await.

## :100: Pour tester
1. Mettre `FT_METRICS=yes`
2. Voir que les informations de metrics sont toujours envoyé
