### PR TITLE
[FEATURE] Ajout de l'attribut database sur tous les logs

### DIFF
--- a/lib/application/task-cache-hit.js
+++ b/lib/application/task-cache-hit.js
@@ -23,7 +23,7 @@ const logCacheHits = async () => {
     try {
       const connectionString = await databaseStatsRepository.getPgConnectionString(scalingoApp);
       const cacheHit = await getCacheHit(connectionString);
-      logger.info({ event, app: scalingoApp, data: { cacheHit } });
+      logger.info({ event, app: scalingoApp, database: 'postgresql', data: { cacheHit } });
     } catch (error) {
       logger.error(error, {
         task: 'cache-hit-ratio',

--- a/lib/application/task-progress.js
+++ b/lib/application/task-progress.js
@@ -23,7 +23,7 @@ const taskProgress = async () => {
           const operation = view.replace(PROGRESS_VIEW_PREFIX, '');
           const { rows: entries } = await client.query(`SELECT * from ${view}`);
           entries.forEach((entry) =>
-            logger.info({ event: 'progress', app: scalingoApp, data: { operation, ...entry } })
+            logger.info({ event: 'progress', app: scalingoApp, database: 'postgresql', data: { operation, ...entry } })
           );
         }
       } finally {

--- a/lib/application/task-queries-metric.js
+++ b/lib/application/task-queries-metric.js
@@ -9,6 +9,7 @@ async function task(databaseStatsRepository, scalingoApi) {
       logger.info({
         event: 'db-queries-metric',
         app: scalingoApp,
+        database: 'postgresql',
         data,
       });
     } catch (error) {

--- a/lib/application/task-response-time.js
+++ b/lib/application/task-response-time.js
@@ -17,7 +17,7 @@ const taskResponseTime = async () => {
       await client.query(RESPONSE_TIME_QUERY);
       const duration = Date.now() - startTime;
 
-      logger.info({ event: 'response-time-millis', app: scalingoApp, data: { duration } });
+      logger.info({ event: 'response-time-millis', app: scalingoApp, database: 'postgresql', data: { duration } });
 
       client.end();
     } catch (error) {

--- a/lib/application/task-statements.js
+++ b/lib/application/task-statements.js
@@ -7,7 +7,9 @@ async function task() {
     try {
       const queryStats = await databaseStatsRepository.getPgQueryStats(scalingoApp);
 
-      queryStats.forEach((query) => logger.info({ event: 'db-query-stats', app: scalingoApp, data: query }));
+      queryStats.forEach((query) =>
+        logger.info({ event: 'db-query-stats', app: scalingoApp, database: 'postgresql', data: query })
+      );
 
       await databaseStatsRepository.resetPgQueryStats(scalingoApp);
     } catch (error) {


### PR DESCRIPTION
## :unicorn: Problème
Les événements n'ont pas tous l'attribut `database`, pour des raisons historique. Par défaut c'est du postgresql.

## :robot: Solution
Pour être cohérent, rajout de l'attribut `database` avec la valeur `postgresql`.

## :100: Pour tester
1. Activer les différents FT
2. Voir que l'attribut `database` est rempli avec la valeur `postgresql`.
