### PR TITLE
Monitor locked queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,4 +55,4 @@ jobs:
           name: Run test
           command: npm run test
           environment:
-            TEST_DATABASE_URL: postgres://user@localhost:5432/database
+            DATABASE_URL: postgres://user@localhost:5432/database

--- a/config.js
+++ b/config.js
@@ -29,7 +29,6 @@ const config = {
   CACHE_HIT_RATIO_SCHEDULE: process.env.CACHE_HIT_RATIO_SCHEDULE || DEFAULT_CACHE_HIT_RATIO_SCHEDULE,
   QUERIES_METRIC_SCHEDULE: process.env.QUERIES_METRIC_SCHEDULE || DEFAULT_QUERIES_METRIC_SCHEDULE,
   SLOW_QUERY_DURATION_NANO_THRESHOLD: (process.env.SLOW_QUERY_DURATION_SECONDS_THRESHOLD || 5 * 60) * 10 ** 9,
-  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
 };
 
 if (process.env.NODE_ENV === 'test') {
@@ -37,6 +36,7 @@ if (process.env.NODE_ENV === 'test') {
   config.SCALINGO_APPS = ['application-1', 'application-2'];
   config.FT_QUERIES_METRIC = true;
   config.QUERIES_METRIC_SCHEDULE = eachSecond;
+  config.DATABASE_URL = process.env.DATABASE_URL || 'postgres://pix@localhost:5432/db-stats';
 }
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -6,7 +6,7 @@ const DEFAULT_RESPONSE_TIME_QUERY = 'SELECT pg_sleep(1)';
 const DEFAULT_PROGRESS_SCHEDULE = '0 */10 * * * *';
 const DEFAULT_CACHE_HIT_RATIO_SCHEDULE = '0 */10 * * * *';
 const DEFAULT_QUERIES_METRIC_SCHEDULE = '*/10 * * * * *';
-
+const DEFAULT_BLOCKING_QUERIES_SCHEDULE = '0 */10 * * * *';
 function _isFeatureEnabled(valueString) {
   return valueString === 'yes';
 }
@@ -21,6 +21,7 @@ const config = {
   FT_PROGRESS: _isFeatureEnabled(process.env.FT_PROGRESS),
   FT_CACHE_HIT_RATIO: _isFeatureEnabled(process.env.FT_CACHE_HIT_RATIO),
   FT_QUERIES_METRIC: _isFeatureEnabled(process.env.FT_QUERIES_METRIC),
+  FT_BLOCKING_QUERIES: _isFeatureEnabled(process.env.FT_BLOCKING_QUERIES),
   METRICS_SCHEDULE: process.env.METRICS_SCHEDULE,
   STATEMENTS_SCHEDULE: process.env.STATEMENTS_SCHEDULE,
   RESPONSE_TIME_SCHEDULE: process.env.RESPONSE_TIME_SCHEDULE,
@@ -28,7 +29,9 @@ const config = {
   PROGRESS_SCHEDULE: process.env.PROGRESS_SCHEDULE || DEFAULT_PROGRESS_SCHEDULE,
   CACHE_HIT_RATIO_SCHEDULE: process.env.CACHE_HIT_RATIO_SCHEDULE || DEFAULT_CACHE_HIT_RATIO_SCHEDULE,
   QUERIES_METRIC_SCHEDULE: process.env.QUERIES_METRIC_SCHEDULE || DEFAULT_QUERIES_METRIC_SCHEDULE,
+  BLOCKING_QUERIES_SCHEDULE: process.env.BLOCKING_QUERIES_SCHEDULE || DEFAULT_BLOCKING_QUERIES_SCHEDULE,
   SLOW_QUERY_DURATION_NANO_THRESHOLD: (process.env.SLOW_QUERY_DURATION_SECONDS_THRESHOLD || 5 * 60) * 10 ** 9,
+  BLOCKING_QUERIES_MINUTES_THRESHOLD: process.env.BLOCKING_QUERIES_MINUTES_THRESHOLD || 15,
 };
 
 if (process.env.NODE_ENV === 'test') {
@@ -36,7 +39,9 @@ if (process.env.NODE_ENV === 'test') {
   config.SCALINGO_APPS = ['application-1', 'application-2'];
   config.FT_QUERIES_METRIC = true;
   config.QUERIES_METRIC_SCHEDULE = eachSecond;
+  config.BLOCKING_QUERIES_SCHEDULE = eachSecond;
   config.DATABASE_URL = process.env.DATABASE_URL || 'postgres://pix@localhost:5432/db-stats';
+  config.BLOCKING_QUERIES_MINUTES_THRESHOLD = process.env.BLOCKING_QUERIES_MINUTES_THRESHOLD = 0;
 }
 
 module.exports = config;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,5 +8,5 @@ services:
       - '${PIX_DATABASE_PORT:-5432}:5432'
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: user
-      POSTGRES_DB: database
+      POSTGRES_USER: pix
+      POSTGRES_DB: db-stats

--- a/lib/application/run-task-blocking-queries.js
+++ b/lib/application/run-task-blocking-queries.js
@@ -1,0 +1,5 @@
+const { logBlockingQueries } = require('./task-blocking-queries');
+
+(async () => {
+  await logBlockingQueries();
+})();

--- a/lib/application/schedule-tasks.js
+++ b/lib/application/schedule-tasks.js
@@ -29,6 +29,9 @@ const {
 
   FT_QUERIES_METRIC,
   QUERIES_METRIC_SCHEDULE,
+
+  FT_BLOCKING_QUERIES,
+  BLOCKING_QUERIES_SCHEDULE,
 } = require('../../config');
 const taskMetrics = require('./task-metrics');
 const taskStatements = require('./task-statements');
@@ -36,7 +39,7 @@ const taskResponseTime = require('./task-response-time');
 const taskProgress = require('./task-progress');
 const taskQueriesMetric = require('./task-queries-metric');
 const { logCacheHits: taskCacheHit } = require('./task-cache-hit');
-
+const { logBlockingQueries: taskBlockingQueries } = require('./task-blocking-queries');
 const scalingoApi = require('../infrastructure/scalingo-api');
 const databaseStatsRepository = require('../infrastructure/database-stats-repository');
 
@@ -78,6 +81,12 @@ const tasks = [
     task: async () => {
       await taskQueriesMetric.run(databaseStatsRepository, scalingoApi);
     },
+  },
+  {
+    name: 'blocking-queries',
+    enabled: FT_BLOCKING_QUERIES,
+    schedule: BLOCKING_QUERIES_SCHEDULE,
+    task: taskBlockingQueries,
   },
 ];
 

--- a/lib/application/task-blocking-queries.js
+++ b/lib/application/task-blocking-queries.js
@@ -1,0 +1,57 @@
+const { Client } = require('pg');
+
+const getBlockingQueries = async (connectionString) => {
+  const client = new Client(connectionString);
+
+  try {
+    await client.connect();
+    const result = await client.query(`
+      SELECT
+        waiting.locktype AS waiting_locktype,
+        waiting.relation :: regclass AS waiting_table,
+        waiting_stm.query AS waiting_query,
+        waiting.mode AS waiting_mode,
+        waiting.pid AS waiting_pid,
+        blocking.locktype AS blocking_locktype,
+        blocking.relation :: regclass AS blocking_table,
+        blocking_stm.query AS blocking_query,
+        EXTRACT(
+          epoch
+          FROM
+            now() - blocking_stm.query_start
+        )  :: int AS blocking_duration,
+        blocking.mode AS blocking_mode,
+        blocking.pid AS blocking_pid,
+        blocking.granted AS blocking_granted
+      FROM
+        pg_catalog.pg_locks AS waiting
+        JOIN pg_catalog.pg_stat_activity AS waiting_stm ON (
+          waiting_stm.pid = waiting.pid
+        )
+        JOIN pg_catalog.pg_locks AS blocking ON (
+          (
+            waiting.database = blocking.database
+            AND waiting.relation = blocking.relation
+          )
+          OR waiting.transactionid = blocking.transactionid
+        )
+        JOIN pg_catalog.pg_stat_activity AS blocking_stm ON (blocking_stm.pid = blocking.pid)
+      WHERE 
+        waiting.pid <> blocking.pid 
+        AND EXTRACT( epoch FROM now() - blocking_stm.query_start ) :: int >=  ${BLOCKING_QUERIES_MINUTES_THRESHOLD} * 60
+        ORDER BY
+        waiting_stm.query_start ASC;`);
+    return result.rows;
+  } finally {
+    await client.end();
+  }
+};
+
+  return false;
+const logBlockingQueries = async () => {
+};
+
+module.exports = {
+  logBlockingQueries,
+  getBlockingQueries,
+};

--- a/lib/application/task-blocking-queries.js
+++ b/lib/application/task-blocking-queries.js
@@ -1,4 +1,7 @@
 const { Client } = require('pg');
+const { SCALINGO_APPS, BLOCKING_QUERIES_MINUTES_THRESHOLD } = require('../../config');
+const databaseStatsRepository = require('../infrastructure/database-stats-repository');
+const logger = require('../infrastructure/logger');
 
 const getBlockingQueries = async (connectionString) => {
   const client = new Client(connectionString);
@@ -38,6 +41,7 @@ const getBlockingQueries = async (connectionString) => {
         JOIN pg_catalog.pg_stat_activity AS blocking_stm ON (blocking_stm.pid = blocking.pid)
       WHERE 
         waiting.pid <> blocking.pid 
+        AND blocking.granted
         AND EXTRACT( epoch FROM now() - blocking_stm.query_start ) :: int >=  ${BLOCKING_QUERIES_MINUTES_THRESHOLD} * 60
         ORDER BY
         waiting_stm.query_start ASC;`);
@@ -47,8 +51,22 @@ const getBlockingQueries = async (connectionString) => {
   }
 };
 
-  return false;
 const logBlockingQueries = async () => {
+  const event = 'blocking-queries';
+  for (const scalingoApp of SCALINGO_APPS) {
+    try {
+      const connectionString = await databaseStatsRepository.getPgConnectionString(scalingoApp);
+      const blockingQueries = await getBlockingQueries(connectionString);
+      for (const blockingQuery of blockingQueries) {
+        logger.info({ event, app: scalingoApp, database: 'postgresql', data: blockingQuery });
+      }
+    } catch (error) {
+      logger.error(error, {
+        task: 'blocking-queries',
+        app: scalingoApp,
+      });
+    }
+  }
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preinstall": "npx check-engine",
     "progress": "node ./lib/application/run-task-progress.js",
     "queries-metric": "node ./lib/application/run-task-queries-metric.js",
+    "blocking-queries": "node ./lib/application/run-task-blocking-queries.js",
     "response-time": "node ./lib/application/run-task-response-time.js",
     "schedule-tasks": "node ./lib/application/schedule-tasks.js",
     "statements": "node ./lib/application/run-task-statements.js",

--- a/sample.env
+++ b/sample.env
@@ -89,6 +89,8 @@ FT_PROGRESS=yes
 # value: yes to activate
 FT_QUERIES_METRIC=yes
 
+FT_BLOCKING_QUERIES=yes
+
 # Execution periodicity (for node-cron library, in a cron-like pattern)
 # Cron patterns have five fields, and 1 minute as the finest granularity
 # But this library has six fields, with 1 second as the finest granularity.

--- a/tests/integration/application/task-blocking-queries_test.js
+++ b/tests/integration/application/task-blocking-queries_test.js
@@ -1,0 +1,84 @@
+const { Client } = require('pg');
+const { expect } = require('../../test-helper');
+const { getBlockingQueries, logBlockingQueries } = require('../../../lib/application/task-blocking-queries');
+const { DATABASE_URL } = require('../../../config');
+
+async function createTable() {
+  const client = new Client(DATABASE_URL);
+  try {
+    await client.connect();
+    await client.query('CREATE TABLE blocking_table (id int, name varchar(2), value int);');
+  } finally {
+    await client.end();
+  }
+}
+
+async function cleanupTable() {
+  const client = new Client(DATABASE_URL);
+  try {
+    await client.connect();
+    await client.query(`DROP TABLE blocking_table CASCADE;`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function execute(client = new Client(DATABASE_URL), query) {
+  await client.connect();
+  await client.query(query);
+}
+
+describe('#getBlockingQueries', function () {
+  beforeEach(async function () {
+    await createTable();
+  });
+  afterEach(async function () {
+    await cleanupTable();
+  });
+
+  it('should return metrics', async function () {
+    // given
+    const client1 = new Client(DATABASE_URL);
+    const client2 = new Client(DATABASE_URL);
+    await execute(client1, 'BEGIN; ALTER TABLE blocking_table DROP COLUMN value;');
+    execute(client2, 'INSERT into blocking_table VALUES (1, "tt" , 12) ;');
+
+    // when
+    const result = await getBlockingQueries(DATABASE_URL);
+
+    // then
+    await client1.end();
+    await client2.end();
+
+    expect(result.length).to.equal(2);
+    expect(result[0]).to.include({
+      waiting_locktype: 'relation',
+      waiting_table: 'blocking_table',
+      waiting_query: 'BEGIN; ALTER TABLE blocking_table DROP COLUMN value;',
+      waiting_mode: 'AccessExclusiveLock',
+      blocking_locktype: 'relation',
+      blocking_table: 'blocking_table',
+      blocking_query: 'INSERT into blocking_table VALUES (1, "tt" , 12) ;',
+      blocking_mode: 'RowExclusiveLock',
+      blocking_granted: false,
+    });
+    expect(result[0].blocking_duration).to.be.a('number');
+    expect(result[0].blocking_pid).to.be.a('number');
+    expect(result[0].waiting_pid).to.be.a('number');
+
+    expect(result[1]).to.include({
+      waiting_locktype: 'relation',
+      waiting_table: 'blocking_table',
+      waiting_query: 'INSERT into blocking_table VALUES (1, "tt" , 12) ;',
+      waiting_mode: 'RowExclusiveLock',
+      blocking_locktype: 'relation',
+      blocking_table: 'blocking_table',
+      blocking_query: 'BEGIN; ALTER TABLE blocking_table DROP COLUMN value;',
+      blocking_mode: 'AccessExclusiveLock',
+      blocking_granted: true,
+    });
+    expect(result[1].blocking_duration).to.be.a('number');
+    expect(result[1].blocking_pid).to.be.a('number');
+    expect(result[1].waiting_pid).to.be.a('number');
+  });
+});

--- a/tests/integration/application/task-cache-hit_test.js
+++ b/tests/integration/application/task-cache-hit_test.js
@@ -1,6 +1,6 @@
 const { expect, nock } = require('../../test-helper');
 const { getCacheHit, logCacheHits } = require('../../../lib/application/task-cache-hit');
-const { TEST_DATABASE_URL: connexionString } = require('../../../config');
+const { DATABASE_URL: connexionString } = require('../../../config');
 
 describe('#getCacheHit', function () {
   it('should return a positive percentage', async function () {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une query pose un lock sur des données dont d'autre query ont besoin, nous n'avons aucune information lorsque ce lock dure longtemps, et bloque de nombreuses query, alors que cela peut avoir un impact majeur sur les performances de l'application 

## :robot: Solution

Créer une tache qui va consulter une vue qui contient toutes les informations du blocking tree (si la vue existe).
Avec ces informations, logguer le pid bloquant ainsi que la query (truncate pour ne pas exploser la taille du log), le nombre de pid qu'elle bloque, ainsi que la durée de cette requête (`select now()-query_start from pg_stat_activity where pid=blocking_pid`) .

## :rainbow: Remarques

On limitera les logs avec des conditions sur le temps de blocage, et le nombre de pid bloqués assez haute pour ne pas casser

## :100: Pour tester

Sur la Review App, on a créé la table suivante :

```
CREATE TABLE toto
(
    id int type_donnees,
    name varchar(2),
    value int
)
```

On peut utiliser cette table pour créer une query bloquante simple. 

Ouvrir une première requête avec une transaction ouverte : 

```
# pgsql terminal 1
BEGIN;
ALTER TABLE toto DROP COLUMN value;
```

Ouvrir un second terminal et lancer une requête d'insertion sur la table : 

```
# pgsql terminal 2
INSERT INTO toto VALUES (5,'hi',2);
```

La requête du second terminal est desormais bloquée par la première.`

Ensuite, en faisant un appel sur la vue `blocking_tree`, on obtient les informations du processus bloqué : 

```
#psql terminal 3
select * from blocking_tree;
```
