### PR TITLE
[TECH] Ajout d'informations sur les queries bloquées et bloquantes

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,7 +40,7 @@ if (process.env.NODE_ENV === 'test') {
   config.FT_QUERIES_METRIC = true;
   config.QUERIES_METRIC_SCHEDULE = eachSecond;
   config.BLOCKING_QUERIES_SCHEDULE = eachSecond;
-  config.DATABASE_URL = process.env.DATABASE_URL || 'postgres://pix@localhost:5432/db-stats';
+  config.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user@localhost:5432/db-stats';
   config.BLOCKING_QUERIES_MINUTES_THRESHOLD = process.env.BLOCKING_QUERIES_MINUTES_THRESHOLD = 0;
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,5 +8,5 @@ services:
       - '${PIX_DATABASE_PORT:-5432}:5432'
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: pix
+      POSTGRES_USER: user
       POSTGRES_DB: db-stats

--- a/lib/application/task-blocking-queries.js
+++ b/lib/application/task-blocking-queries.js
@@ -18,14 +18,27 @@ const getBlockingQueries = async (connectionString) => {
         blocking.locktype AS blocking_locktype,
         blocking.relation :: regclass AS blocking_table,
         blocking_stm.query AS blocking_query,
+        waiting.waitstart as waiting_for_lock_start,
+        EXTRACT(
+          epoch
+          FROM
+            now() - waiting.waitstart
+        )  :: int AS waiting_for_lock_duration,
         EXTRACT(
           epoch
           FROM
             now() - blocking_stm.query_start
         )  :: int AS blocking_duration,
+        EXTRACT(
+          epoch
+          FROM
+            now() - waiting_stm.query_start
+        )  :: int AS waiting_duration,
         blocking.mode AS blocking_mode,
         blocking.pid AS blocking_pid,
-        blocking.granted AS blocking_granted
+        blocking.granted AS blocking_granted,
+        waiting_stm.usename as waiting_usr,
+        blocking_stm.usename as blocking_usr
       FROM
         pg_catalog.pg_locks AS waiting
         JOIN pg_catalog.pg_stat_activity AS waiting_stm ON (
@@ -39,8 +52,8 @@ const getBlockingQueries = async (connectionString) => {
           OR waiting.transactionid = blocking.transactionid
         )
         JOIN pg_catalog.pg_stat_activity AS blocking_stm ON (blocking_stm.pid = blocking.pid)
-      WHERE 
-        waiting.pid <> blocking.pid 
+      WHERE
+        waiting.pid <> blocking.pid
         AND blocking.granted
         AND EXTRACT( epoch FROM now() - blocking_stm.query_start ) :: int >=  ${BLOCKING_QUERIES_MINUTES_THRESHOLD} * 60
         ORDER BY

--- a/tests/integration/application/task-blocking-queries_test.js
+++ b/tests/integration/application/task-blocking-queries_test.js
@@ -62,8 +62,13 @@ describe('#getBlockingQueries', function () {
       blocking_query: 'BEGIN; ALTER TABLE blocking_table DROP COLUMN value;',
       blocking_mode: 'AccessExclusiveLock',
       blocking_granted: true,
+      waiting_usr: 'user',
+      blocking_usr: 'user',
     });
+    expect(result[0].waiting_for_lock_start).to.be.a('date');
+    expect(result[0].waiting_for_lock_duration).to.be.a('number');
     expect(result[0].blocking_duration).to.be.a('number');
+    expect(result[0].waiting_duration).to.be.a('number');
     expect(result[0].blocking_pid).to.be.a('number');
     expect(result[0].waiting_pid).to.be.a('number');
   });


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons pas toutes les informations nécessaires pour nous permettre d'investiguer les incidents : 

- Utilisateurs
- Durée des deux query
- Date de démarrage de l'attente du lock

## :robot: Solution

Ajouter ces informations dans la requête de BDD

## :100: Pour tester

Lancer les requêtes sur une bdd observée en ouvrant deux terminaux différent: 

```
# pgsql terminal 1
CREATE TABLE test_blocking_queries
(
    id int,
    name varchar(2),
    value int
);
```

```
# pgsql terminal 1
BEGIN;
ALTER TABLE test_blocking_queries DROP COLUMN value;
# ce terminal reste en attente sur la transaction ouverte
```

```
# pgsql terminal 2
INSERT INTO test_blocking_queries VALUES (5,'hi',2);
# ce terminal semble inactif, parce que la requête est bloquée
```
