### PR TITLE
[TECH] Monter les versions des images postgresql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
   build_and_test:
     docker:
       - image: cimg/node:20.8.1
-      - image: postgres:14.8-alpine
+      - image: postgres:14.10-alpine
         environment:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_USER: user

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:14.8-alpine
+    image: postgres:14.10-alpine
     container_name: pix-database-statistics
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version des addons postgresql et redis est proposée par Scalingo et la montée de version va être effectuée. Cependant, les images docker sont encore sur les anciennes versions.


## :robot: Solution
Mettre à jour la version de l'image postgresql de la version 14.8 à la version 14.10
