### PR TITLE
[BUGFIX] Corriger l'exécution de la tâche metrics

### DIFF
--- a/lib/application/schedule-tasks.js
+++ b/lib/application/schedule-tasks.js
@@ -93,3 +93,5 @@ export const schedule = ({ runCommand = run } = {}) => {
     }
   });
 };
+
+schedule();

--- a/lib/application/task-metrics.js
+++ b/lib/application/task-metrics.js
@@ -1,14 +1,15 @@
 import { getAvailableDatabases, getDBMetrics } from '../infrastructure/database-stats-repository.js';
 import { info, error } from '../infrastructure/logger.js';
+import * as scalingoApi from '../infrastructure/scalingo-api.js';
 import config from '../../config.js';
 
 async function taskMetrics() {
-  config.SCALINGO_APPS.forEach(async (scalingoApp) => {
+  for (const scalingoApp of config.SCALINGO_APPS) {
     try {
-      const databases = await getAvailableDatabases(scalingoApp);
+      const databases = await getAvailableDatabases(scalingoApi, scalingoApp);
       await Promise.all(
         databases.map(async ({ name, id: addonId }) => {
-          const metrics = await getDBMetrics(scalingoApp, addonId);
+          const metrics = await getDBMetrics(scalingoApi, scalingoApp, addonId);
 
           info({
             event: 'db-metrics',
@@ -24,7 +25,7 @@ async function taskMetrics() {
         app: scalingoApp,
       });
     }
-  });
+  }
 }
 
 export default taskMetrics;


### PR DESCRIPTION
## :unicorn: Problème
Suite au passage en ESM, les events `db-metrics` ne sont pas loggés à cause d'un problème d'injection de dépendance. Cet event nous permet notamment de vérifier la charge CPU et l'utilisation de l'espace disque des bases de données chez Scalingo. 
De plus, le scheduler n'étais jamais lancé.

## :robot: Solution
- Corriger l'injection de dépendance pour la tâche metrics.
- Exécuter le scheduler.

## :100: Pour tester
Regarder les logs du container et vérifier qu'il log bien les métriques suivantes (configuration similaire à la production sur pix-api-recette et pix-api-integration)



https://dashboard.scalingo.com/apps/osc-fr1/pix-db-stats-review-pr102/logs
