### PR TITLE
[BUGFIX] Corriger les imports de run-task-queries-metric

### DIFF
--- a/lib/application/run-task-queries-metric.js
+++ b/lib/application/run-task-queries-metric.js
@@ -1,6 +1,6 @@
 import { run } from './task-queries-metric.js';
-import scalingoApi from '../infrastructure/scalingo-api.js';
-import databaseStatsRepository from '../infrastructure/database-stats-repository/js';
+import * as scalingoApi from '../infrastructure/scalingo-api.js';
+import * as databaseStatsRepository from '../infrastructure/database-stats-repository.js';
 
 (async () => {
   await run(databaseStatsRepository, scalingoApi);

--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -13,7 +13,7 @@ function truncate(queryString) {
   return queryString;
 }
 
-export async function getAvailableDatabases(scalingoApi, scalingoApp) {
+async function getAvailableDatabases(scalingoApi, scalingoApp) {
   const addons = await scalingoApi.getAddons(scalingoApp);
 
   return addons
@@ -28,7 +28,7 @@ export async function getAvailableDatabases(scalingoApi, scalingoApp) {
     });
 }
 
-export async function getDBMetrics(scalingoApi, scalingoApp, addonId) {
+async function getDBMetrics(scalingoApi, scalingoApp, addonId) {
   const leaderNodeId = await _getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId);
   const metrics = await scalingoApi.getDbMetrics(scalingoApp, addonId);
   const leaderMetrics = metrics.instances_metrics[leaderNodeId];
@@ -45,16 +45,16 @@ export async function getDBMetrics(scalingoApi, scalingoApp, addonId) {
   };
 }
 
-export async function getPgConnectionString(scalingoApp) {
+async function getPgConnectionString(scalingoApp) {
   return scalingoApi.getPgConnectionString(scalingoApp);
 }
 
-export async function getPgQueryStats(scalingoApp) {
+async function getPgQueryStats(scalingoApp) {
   const { result } = await scalingoApi.getPgQueryStats(scalingoApp);
   return result || [];
 }
 
-export async function getPgQueriesMetric(injectedScalingoApi = scalingoApi, scalingoApp) {
+async function getPgQueriesMetric(injectedScalingoApi = scalingoApi, scalingoApp) {
   const { result: queries } = await injectedScalingoApi.getPgRunningQueries(scalingoApp);
 
   const activeQueries = queries.filter((query) => query.state === 'active');
@@ -77,7 +77,7 @@ export async function getPgQueriesMetric(injectedScalingoApi = scalingoApi, scal
   };
 }
 
-export async function resetPgQueryStats(scalingoApp) {
+async function resetPgQueryStats(scalingoApp) {
   await scalingoApi.resetPgStats(scalingoApp);
 }
 
@@ -85,3 +85,12 @@ async function _getDatabaseLeaderNodeId(scalingoApi, scalingoApp, addonId) {
   const instancesStatus = await scalingoApi.getInstancesStatus(scalingoApp, addonId);
   return instancesStatus.filter(({ type, role }) => type === 'db-node' && role === 'leader').map(({ id }) => id)[0];
 }
+
+export {
+  getAvailableDatabases,
+  getDBMetrics,
+  getPgConnectionString,
+  getPgQueryStats,
+  getPgQueriesMetric,
+  resetPgQueryStats,
+};

--- a/lib/infrastructure/scalingo-api.js
+++ b/lib/infrastructure/scalingo-api.js
@@ -21,39 +21,39 @@ const _getAddonTokenFromApplication = async function (scalingoApp, addonId) {
   return _getAddonToken(scalingoApp, scalingoApplicationToken, addonId);
 };
 
-export async function getAddons(scalingoApp) {
+async function getAddons(scalingoApp) {
   const scalingoApplicationToken = await _getScalingoApplicationToken();
   return _getAddons(scalingoApp, scalingoApplicationToken);
 }
 
-export async function getDbMetrics(scalingoApp, addonId) {
+async function getDbMetrics(scalingoApp, addonId) {
   const addonToken = await _getAddonTokenFromApplication(scalingoApp, addonId);
   return _getDbMetrics(addonToken, addonId);
 }
 
-export async function getDbDisk(scalingoApp, addonId, leaderNodeId) {
+async function getDbDisk(scalingoApp, addonId, leaderNodeId) {
   const addonToken = await _getAddonTokenFromApplication(scalingoApp, addonId);
 
   return _getDbDisk(addonToken, addonId, leaderNodeId);
 }
 
-export async function getDbDiskIO(scalingoApp, addonId, leaderNodeId) {
+async function getDbDiskIO(scalingoApp, addonId, leaderNodeId) {
   const addonToken = await _getAddonTokenFromApplication(scalingoApp, addonId);
 
   return _getDbDiskIO(addonToken, addonId, leaderNodeId);
 }
 
-export async function getInstancesStatus(scalingoApp, addonId) {
+async function getInstancesStatus(scalingoApp, addonId) {
   const addonToken = await _getAddonTokenFromApplication(scalingoApp, addonId);
 
   return _getInstancesStatus(addonToken, addonId);
 }
 
-export async function getPgConnectionString(scalingoApp) {
+function getPgConnectionString(scalingoApp) {
   return _getScalingoPgUrl(scalingoApp);
 }
 
-export async function getPgQueryStats(scalingoApp) {
+async function getPgQueryStats(scalingoApp) {
   const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
   const config = requestConfig(token);
@@ -63,7 +63,7 @@ export async function getPgQueryStats(scalingoApp) {
   return stats;
 }
 
-export async function getPgRunningQueries(scalingoApp, injectedCredentials = _getScalingoDatabaseAPICredentials) {
+async function getPgRunningQueries(scalingoApp, injectedCredentials = _getScalingoDatabaseAPICredentials) {
   const { addonId, token } = await injectedCredentials(scalingoApp);
   const config = requestConfig(token);
   const { data: stats } = await httpServicePost(`${DB_API_URL}/api/databases/${addonId}/action`, config, {
@@ -72,7 +72,7 @@ export async function getPgRunningQueries(scalingoApp, injectedCredentials = _ge
   return stats;
 }
 
-export async function resetPgStats(scalingoApp) {
+async function resetPgStats(scalingoApp) {
   const { addonId, token } = await _getScalingoDatabaseAPICredentials(scalingoApp);
 
   const config = requestConfig(token);
@@ -158,3 +158,15 @@ async function _getAddonToken(scalingoApp, token, addonId) {
   const { data } = await httpServicePost(url, config);
   return data.addon.token;
 }
+
+export {
+  getAddons,
+  getDbMetrics,
+  getDbDisk,
+  getDbDiskIO,
+  getInstancesStatus,
+  getPgConnectionString,
+  getPgQueryStats,
+  getPgRunningQueries,
+  resetPgStats,
+};


### PR DESCRIPTION
## :unicorn: Problème
La tâche queries-metric ne peut pas être exécutée en local à cause d'un problème d'imports.

## :robot: Solution
Corriger le problème d'import

## :100: Pour tester
Lancer la commande `scalingo --region osc-fr1 -a pix-db-stats-review-pr111 run "node lib/application/run-task-queries-metric.js"` et vérifier qu'il n'y a pas d'erreurs
