### PR TITLE
[BUGFIX] Corriger getPgQueriesMetric lorsque le résultat est null

### DIFF
--- a/lib/infrastructure/database-stats-repository.js
+++ b/lib/infrastructure/database-stats-repository.js
@@ -57,7 +57,7 @@ async function getPgQueryStats(scalingoApp) {
 async function getPgQueriesMetric(injectedScalingoApi = scalingoApi, scalingoApp) {
   const { result: queries } = await injectedScalingoApi.getPgRunningQueries(scalingoApp);
 
-  const activeQueries = queries.filter((query) => query.state === 'active');
+  const activeQueries = queries ? queries.filter((query) => query.state === 'active') : [];
 
   const slowQueries = activeQueries
     .filter((query) => query.query_duration >= SLOW_QUERY_DURATION_NANO_THRESHOLD)

--- a/tests/integration/infrastructure/database-stats-repository_test.js
+++ b/tests/integration/infrastructure/database-stats-repository_test.js
@@ -162,6 +162,23 @@ describe('database-stats-repository', function () {
       pid: 42,
     };
 
+    describe('When getPgRunningQueries return a null result', function () {
+      it('it should not throw an exception', async function () {
+        // given
+        const scalingoApp = 'application';
+        const getPgRunningQueriesStub = sinon.stub();
+        getPgRunningQueriesStub.resolves({ result: null });
+        const scalingoApi = { getPgRunningQueries: getPgRunningQueriesStub };
+
+        // when
+        const response = await getPgQueriesMetric(scalingoApi, scalingoApp);
+
+        // then
+        expect(getPgRunningQueriesStub).to.have.been.calledOnceWithExactly(scalingoApp);
+        expect(response).to.deep.equal({ activeQueriesCount: 0, slowQueriesCount: 0, slowQueries: [] });
+      });
+    });
+
     describe('Given running query with less than 250', function () {
       it('should not truncate the returned query', async function () {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Nous avons eu [des erreurs](https://app.datadoghq.eu/logs?query=service%3Apix-db-stats-production%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1723546680199&to_ts=1723546680413&live=false) pendant quelques heures à cause d'une valeur null retournée, apparemment, par l'API de Scalingo. Cette valeur n'était pas gérée dans le code.  

## :robot: Solution
Ne pas lancer d'exception lorsque le résultat des running queries est null.
