### PR TITLE
[TECH] Ne pas logger le contenu complet de l'erreur AxiosError

### DIFF
--- a/lib/infrastructure/logger.js
+++ b/lib/infrastructure/logger.js
@@ -5,6 +5,5 @@ export const info = ({ event, app, database, data }) => {
 };
 
 export const error = (error, { task, app }) => {
-  console.error(error);
   console.log(JSON.stringify({ status: 'ERROR', message: error.message, task, app }));
 };


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lorsqu'une requête faite via Axios renvoie autre chose qu'une 2XX, on log l'entièreté du contenu de l'erreur ce qui comprend notamment les headers (dont le header Authorization). Ce fonctionnement fait fuiter des secrets et génère une quantité de logs inutiles.  

## :robot: Solution
Supprimer le console.log qui log tous les attributs de l'objet Error.
